### PR TITLE
replaced #ifdef TARGET_OS_IPHONE with #if TARGET_OS_IPHONE

### DIFF
--- a/AudioStreamer.xcworkspace/contents.xcworkspacedata
+++ b/AudioStreamer.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:iPhoneStreamingPlayer.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:MacStreamingPlayer.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -181,6 +181,12 @@ extern NSString * const ASUpdateMetadataNotification;
 	unsigned int dataBytesRead;							// how many bytes of data have been read
 	NSMutableString *metaDataString;			// the metaDataString
    // Shoutcast metadata -- end --
+   
+   // Level Meter support -- begin --
+   // Added by KT. Found in repo at: https://github.com/idevsoftware/AudioStreamer
+   UInt32 numberOfChannels;	// Number of audio channels in the stream (1 = mono, 2 = stereo)
+   // Level Meter support -- end --
+
 }
 
 @property AudioStreamerErrorCode errorCode;
@@ -190,6 +196,14 @@ extern NSString * const ASUpdateMetadataNotification;
 @property (readwrite) UInt32 bitRate;
 @property (readonly) NSDictionary *httpHeaders;
 @property (assign) BOOL retrieveShoutcastMetaData;
+
+// Level Meter support -- begin --
+// Added by KT. Found in repo at: https://github.com/idevsoftware/AudioStreamer
+@property (readonly) UInt32 numberOfChannels;
+@property (assign, getter=isMeteringEnabled) BOOL meteringEnabled;
+- (float)peakPowerForChannel:(NSUInteger)channelNumber;
+- (float)averagePowerForChannel:(NSUInteger)channelNumber;
+// Level Meter support -- end --
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -12,7 +12,7 @@
 //  appreciated but not required.
 //
 
-#ifdef TARGET_OS_IPHONE			
+#if TARGET_OS_IPHONE			
 #import <UIKit/UIKit.h>
 #else
 #import <Cocoa/Cocoa.h>
@@ -155,7 +155,7 @@ extern NSString * const ASStatusChangedNotification;
 								// time)
 	double packetDuration;		// sample rate times frames per packet
 	double lastProgress;		// last calculated progress point
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 	BOOL pausedByInterruption;
 #endif
 }

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -98,10 +98,8 @@ typedef enum
 
 extern NSString * const ASStatusChangedNotification;
 extern NSString * const ASPresentAlertWithTitleNotification;
-
-#ifdef SHOUTCAST_METADATA
+// Shoutcast metadata notification. Must set retrieveShoutcastMetaData to YES to receive this notification.
 extern NSString * const ASUpdateMetadataNotification;
-#endif
 
 @interface AudioStreamer : NSObject
 {
@@ -164,7 +162,8 @@ extern NSString * const ASUpdateMetadataNotification;
 	BOOL pausedByInterruption;
 #endif
 
-#ifdef SHOUTCAST_METADATA
+   // Shoutcast metadata -- begin --
+   BOOL retrieveShoutcastMetaData;
 	BOOL foundIcyStart;
 	BOOL foundIcyEnd;
 	BOOL parsedHeaders;
@@ -172,7 +171,7 @@ extern NSString * const ASUpdateMetadataNotification;
 	unsigned int metaDataBytesRemaining;	// how many bytes of metadata remain to be read
 	unsigned int dataBytesRead;							// how many bytes of data have been read
 	NSMutableString *metaDataString;			// the metaDataString
-#endif
+   // Shoutcast metadata -- end --
 }
 
 @property AudioStreamerErrorCode errorCode;
@@ -181,6 +180,7 @@ extern NSString * const ASUpdateMetadataNotification;
 @property (readonly) double duration;
 @property (readwrite) UInt32 bitRate;
 @property (readonly) NSDictionary *httpHeaders;
+@property (assign) BOOL retrieveShoutcastMetaData;
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -97,6 +97,11 @@ typedef enum
 } AudioStreamerErrorCode;
 
 extern NSString * const ASStatusChangedNotification;
+extern NSString * const ASPresentAlertWithTitleNotification;
+
+#ifdef SHOUTCAST_METADATA
+extern NSString * const ASUpdateMetadataNotification;
+#endif
 
 @interface AudioStreamer : NSObject
 {
@@ -157,6 +162,16 @@ extern NSString * const ASStatusChangedNotification;
 	double lastProgress;		// last calculated progress point
 #if TARGET_OS_IPHONE
 	BOOL pausedByInterruption;
+#endif
+
+#ifdef SHOUTCAST_METADATA
+	BOOL foundIcyStart;
+	BOOL foundIcyEnd;
+	BOOL parsedHeaders;
+	unsigned int metaDataInterval;					// how many data bytes between meta data
+	unsigned int metaDataBytesRemaining;	// how many bytes of metadata remain to be read
+	unsigned int dataBytesRead;							// how many bytes of data have been read
+	NSMutableString *metaDataString;			// the metaDataString
 #endif
 }
 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -21,6 +21,10 @@
 #define BitRateEstimationMinPackets 50
 
 NSString * const ASStatusChangedNotification = @"ASStatusChangedNotification";
+NSString * const ASPresentAlertWithTitleNotification = @"ASPresentAlertWithTitleNotification";
+#ifdef SHOUTCAST_METADATA
+NSString * const ASUpdateMetadataNotification = @"ASUpdateMetadataNotification";
+#endif
 
 NSString * const AS_NO_ERROR_STRING = @"No error.";
 NSString * const AS_FILE_STREAM_GET_PROPERTY_FAILED_STRING = @"File stream get property failed.";
@@ -226,6 +230,9 @@ void ASReadStreamCallBack
 	if (self != nil)
 	{
 		url = [aURL retain];
+#ifdef SHOUTCAST_METADATA
+		metaDataString = [[NSMutableString alloc] initWithString:@""];
+#endif
 	}
 	return self;
 }
@@ -239,6 +246,9 @@ void ASReadStreamCallBack
 {
 	[self stop];
 	[url release];
+#ifdef SHOUTCAST_METADATA
+	[metaDataString release];
+#endif
 	[super dealloc];
 }
 
@@ -359,34 +369,14 @@ void ASReadStreamCallBack
 //
 - (void)presentAlertWithTitle:(NSString*)title message:(NSString*)message
 {
-#if TARGET_OS_IPHONE
-	UIAlertView *alert = [
-		[[UIAlertView alloc]
-			initWithTitle:title
-			message:message
-			delegate:self
-			cancelButtonTitle:NSLocalizedString(@"OK", @"")
-			otherButtonTitles: nil]
-		autorelease];
-	[alert
-		performSelector:@selector(show)
-		onThread:[NSThread mainThread]
-		withObject:nil
-		waitUntilDone:NO];
-#else
-	NSAlert *alert =
-		[NSAlert
-			alertWithMessageText:title
-			defaultButton:NSLocalizedString(@"OK", @"")
-			alternateButton:nil
-			otherButton:nil
-			informativeTextWithFormat:message];
-	[alert
-		performSelector:@selector(runModal)
-		onThread:[NSThread mainThread]
-		withObject:nil
-		waitUntilDone:NO];
-#endif
+	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:title, @"title", message, @"message", nil];
+	NSNotification *notification =
+	[NSNotification
+	 notificationWithName:ASPresentAlertWithTitleNotification
+	 object:self
+	 userInfo:userInfo];
+	[[NSNotificationCenter defaultCenter]
+	 postNotification:notification];
 }
 
 //
@@ -620,7 +610,9 @@ void ASReadStreamCallBack
 		// Create the HTTP GET request
 		//
 		CFHTTPMessageRef message= CFHTTPMessageCreateRequest(NULL, (CFStringRef)@"GET", (CFURLRef)url, kCFHTTPVersion1_1);
-		
+#ifdef SHOUTCAST_METADATA
+		CFHTTPMessageSetHeaderFieldValue(message, CFSTR("icy-metadata"), CFSTR("1"));
+#endif
 		//
 		// If we are creating this request to seek to a location, set the
 		// requested byte range in the headers.
@@ -1131,6 +1123,8 @@ cleanup:
 {
 	@synchronized(self)
 	{
+		if (state == AS_WAITING_FOR_DATA || state == AS_STARTING_FILE_THREAD)
+			return;
 		if (audioQueue &&
 			(state == AS_PLAYING || state == AS_PAUSED ||
 				state == AS_BUFFERING || state == AS_WAITING_FOR_QUEUE_TO_START))
@@ -1157,6 +1151,20 @@ cleanup:
 		[NSThread sleepForTimeInterval:0.1];
 	}
 }
+
+#ifdef SHOUTCAST_METADATA
+- (void)updateMetaData:(NSString *)metaData
+{
+	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:metaData, @"metadata", nil];
+	NSNotification *notification =
+	[NSNotification
+	 notificationWithName:ASUpdateMetadataNotification
+	 object:self
+	 userInfo:userInfo];
+	[[NSNotificationCenter defaultCenter]
+	 postNotification:notification];
+}
+#endif
 
 //
 // handleReadFromStream:eventType:
@@ -1260,7 +1268,8 @@ cleanup:
 			httpHeaders =
 				(NSDictionary *)CFHTTPMessageCopyAllHeaderFields((CFHTTPMessageRef)message);
 			CFRelease(message);
-			
+			//NSLog(@"headers %@", httpHeaders);
+
 			//
 			// Only read the content length if we seeked to time zero, otherwise
 			// we only have a subset of the total bytes.
@@ -1295,6 +1304,11 @@ cleanup:
 		
 		UInt8 bytes[kAQDefaultBufSize];
 		CFIndex length;
+#ifdef SHOUTCAST_METADATA
+      UInt8 bytesNoMetaData[kAQDefaultBufSize];
+      int lengthNoMetaData = 0;
+#endif SHOUTCAST_METADATA
+		
 		@synchronized(self)
 		{
 			if ([self isFinishing] || !CFReadStreamHasBytesAvailable(stream))
@@ -1317,8 +1331,289 @@ cleanup:
 			{
 				return;
 			}
-		}
+#ifdef SHOUTCAST_METADATA
+			// shoutcast parsing code from http://code.google.com/p/audiostreamer-meta/
+			// with modifications by John Fricker
+			// get and handle the shoutcast metadata
 
+			int streamStart = 0;
+			if (metaDataInterval == 0)
+			{
+				CFHTTPMessageRef myResponse = (CFHTTPMessageRef)CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPResponseHeader);
+				UInt32 statusCode = CFHTTPMessageGetResponseStatusCode(myResponse);
+				
+				//CFStringRef myStatusLine = CFHTTPMessageCopyResponseStatusLine(myResponse);
+				
+				if (statusCode == 200)		// "OK" (this is true even for ICY)
+				{
+					// check if this is a ICY 200 OK response
+					NSString *icyCheck = [[[NSString alloc] initWithBytes:bytes length:10 encoding:NSUTF8StringEncoding] autorelease];
+					//NSLog(@"stream bytes %@", [NSString stringWithCString:bytes length:length]); // dataWithBytes:bytes length:1024]);
+					if (icyCheck != nil && [icyCheck caseInsensitiveCompare:@"ICY 200 OK"] == NSOrderedSame)	
+					{
+						foundIcyStart = YES;
+						//NSLog(@"ICY 200 OK");				
+					}
+					else
+					{
+						// is Live365?
+						// get all the headers
+						NSDictionary *reqHeaders = [(NSDictionary *)CFHTTPMessageCopyAllHeaderFields(myResponse) autorelease];
+						//NSLog(@"reqHeaders: %@", reqHeaders);
+						NSString *serverHeader = [reqHeaders valueForKey:@"Server"];
+						if (serverHeader != nil && NSEqualRanges([serverHeader rangeOfString:@"Nanocaster"], NSMakeRange(0, 10))) {
+							NSLog(@"Wrong stream type - can not continue to parse");
+							
+						} else {
+							// Not an ICY response
+							/*NSString *metaInt;
+							metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));	
+							metaDataInterval = [metaInt intValue];
+							[metaInt release];
+							if (metaInt)
+							{
+								parsedHeaders = YES;
+							}*/
+							NSString *metaInt;
+							NSString *contentType;
+							NSString *icyBr;
+							metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));
+							contentType = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Content-Type"));
+							icyBr = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("icy-br"));
+							/*if (contentType) 
+							{
+								// only if we haven't already set a content-type
+								if (!myData.streamContentType)
+								{
+									NSLog(@"Stream Content-Type: %@", contentType);
+									myData.streamContentType = contentType;
+									// if this is not an mp3 stream we need to restart the audio queue
+									if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
+									{
+										[myData restartAudioQueue];
+									}								
+								}
+							}*/
+							/*
+							if (bitRate == 0 && icyBr)
+							{
+								bitRate = [icyBr intValue];
+								NSLog(@"Stream Bitrate: %@", icyBr);
+								[myData updateBitrate:[icyBr intValue]];
+							}
+							*/
+							metaDataInterval = [metaInt intValue];
+							if (metaInt)
+							{
+								NSLog(@"MetaInt: %@", metaInt);
+								parsedHeaders = YES;
+							}
+						}
+					}
+				}
+				else if (statusCode == 302)
+				{
+					NSLog(@"unexpected 302");
+				}
+				else
+				{
+					// Invalid
+				}
+			} // if (metaDataInterval == 0)
+			
+			if (foundIcyStart && !foundIcyEnd)
+			{
+				char c1 = '\0';
+				char c2 = '\0';
+				char c3 = '\0';
+				char c4 = '\0';
+				int lineStart = streamStart;
+				while (YES)
+				{
+					if (streamStart + 3 > length)
+					{
+						break;
+					}
+					
+					c1 = bytes[streamStart];
+					c2 = bytes[streamStart+1];
+					c3 = bytes[streamStart+2];
+					c4 = bytes[streamStart+3];
+					
+					if (c1 == '\r' && c2 == '\n')
+					{		
+						// get the full string
+						NSString *fullString = [[[NSString alloc] initWithBytes:bytes length:streamStart encoding:NSUTF8StringEncoding] autorelease];
+						
+						// get the substring for this line
+						NSString *line = [fullString substringWithRange:NSMakeRange(lineStart, (streamStart-lineStart))];
+						//NSLog(@"Header Line: %@. Length: %d", line, [line length]);
+
+						// check if this is icy-metaint
+						NSArray *lineItems = [line componentsSeparatedByString:@":"];
+						if ([lineItems count] > 1)
+						{
+							if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-metaint"] == NSOrderedSame)
+							{
+								metaDataInterval = [[lineItems objectAtIndex:1] intValue];
+								//NSLog(@"ICY MetaInt: %d", metaDataInterval);
+							}
+						}
+/*						if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-br"] == NSOrderedSame)
+						{
+							uint32_t icybr = [[lineItems objectAtIndex:1] intValue];
+							if (bitRate == 0) {
+								bitRate = icybr;
+								NSLog(@"ICY BR: %d", icybr);
+								[myData updateBitrate:icybr];										
+							}
+						}
+						if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame)
+						{
+							NSLog(@"ICY Stream Content-Type: %@", [lineItems objectAtIndex:1]);
+							// only if we haven't already set the content type
+							if (!myData.streamContentType)
+							{
+								myData.streamContentType = [lineItems objectAtIndex:1];
+								// if this is not an mp3 stream we need to restart the audio queue
+								if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
+								{
+									[myData restartAudioQueue];
+								}										
+							}
+						}
+	*/					
+						// this is the end of a line, the new line starts in 2
+						lineStart = streamStart+2; // (c3)
+						
+						if (c3 == '\r' && c4 == '\n')
+						{
+							foundIcyEnd = YES;
+							break;
+						}
+					}
+					
+					streamStart++;
+				} // end while
+				
+				if (foundIcyEnd)
+				{
+					streamStart = streamStart + 4;
+					//NSLog(@"Found End.");	
+					parsedHeaders = YES;
+				}
+			}
+			
+			if (parsedHeaders)
+			{
+				// look at each byte
+				for (int i=streamStart; i < length; i++)
+				{
+					// is this a metadata byte?
+					if (metaDataBytesRemaining > 0)
+					{
+						//NSLog(@"meta: %C", bytes[i]);
+						[metaDataString appendFormat:@"%C", bytes[i]];
+						
+						metaDataBytesRemaining -= 1;
+						
+						if (metaDataBytesRemaining == 0)
+						{
+							[self updateMetaData:metaDataString];
+							
+							dataBytesRead = 0;
+						}
+						continue;
+					}
+					
+					// is this the interval byte?
+					if (metaDataInterval > 0 && dataBytesRead == metaDataInterval)
+					{
+						metaDataBytesRemaining = bytes[i] * 16;
+						//NSLog(@"Found interval. Interval: %d, Meta Length: %d", metaDataInterval, metaDataBytesRemaining);
+
+						[metaDataString setString:@""];
+						
+						if (metaDataBytesRemaining == 0)
+						{
+							dataBytesRead = 0;
+						}
+						else
+						{
+							// NOOP
+							//NSLog(@"Found interval. Meta bytes remaining: %d", metaDataBytesRemaining);
+						}
+						
+						continue;
+					}
+					
+					// this is a data byte
+					dataBytesRead += 1;
+					
+					// copy the data to the new buffer
+					bytesNoMetaData[lengthNoMetaData] = bytes[i];
+					lengthNoMetaData += 1;
+				} // end for
+				
+				// pthread_mutex_unlock(&mutexMeta);
+			}	// end if parsedHeaders
+#endif
+		}
+#ifdef SHOUTCAST_METADATA
+		if (discontinuous)
+		{
+			/*
+			 * SHOUTcast can send the interval byte by itself. In that case lengthNoMetaData is 0, but
+			 * the interval byte should not be sent to the audio queue. The check for a metaDataInterval == 0
+			 * will make sure that we don't ever send in the interval byte on a stream with metadata
+			 */
+			
+			if (lengthNoMetaData > 0)
+			{
+				//NSLog(@"Parsing no meta bytes (Discontinuous).");
+				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, kAudioFileStreamParseFlag_Discontinuity);
+				if (err)
+				{
+					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+					return;
+				}			
+			}
+			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
+			{
+				//NSLog(@"Parsing normal bytes (Discontinuous).");
+				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
+				if (err)
+				{
+					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+					return;
+				}
+			}
+		}
+		else
+		{
+			if (lengthNoMetaData > 0)
+			{
+				//NSLog(@"Parsing no meta bytes.");
+				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, 0);
+				if (err)
+				{
+					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+					return;
+				}
+			}
+			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
+			{
+				//NSLog(@"Parsing normal bytes.");
+				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
+				if (err)
+				{
+					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+					return;
+				}
+			}
+		} // end discontinuous
+		
+#else
 		if (discontinuous)
 		{
 			err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
@@ -1337,6 +1632,7 @@ cleanup:
 				return;
 			}
 		}
+#endif
 	}
 }
 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -374,14 +374,42 @@ void ASReadStreamCallBack
 //
 - (void)presentAlertWithTitle:(NSString*)title message:(NSString*)message
 {
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:title, @"title", message, @"message", nil];
-	NSNotification *notification =
-	[NSNotification
-	 notificationWithName:ASPresentAlertWithTitleNotification
-	 object:self
-	 userInfo:userInfo];
-	[[NSNotificationCenter defaultCenter]
-	 postNotification:notification];
+   // Modification from the original to post a notification
+   // when an error occurs. The original code is commented
+   // below. Uncomment it if you prefer to have the audio
+   // stream display the alert message.
+   NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:title, @"title", message, @"message", nil];
+   NSNotification *notification = [NSNotification notificationWithName:ASPresentAlertWithTitleNotification object:self userInfo:userInfo];
+   [[NSNotificationCenter defaultCenter] postNotification:notification];
+   
+//#if TARGET_OS_IPHONE
+//	UIAlertView *alert = [
+//                         [[UIAlertView alloc]
+//                          initWithTitle:title
+//                          message:message
+//                          delegate:self
+//                          cancelButtonTitle:NSLocalizedString(@"OK", @"")
+//                          otherButtonTitles: nil]
+//                         autorelease];
+//	[alert
+//    performSelector:@selector(show)
+//    onThread:[NSThread mainThread]
+//    withObject:nil
+//    waitUntilDone:NO];
+//#else
+//	NSAlert *alert =
+//   [NSAlert
+//    alertWithMessageText:title
+//    defaultButton:NSLocalizedString(@"OK", @"")
+//    alternateButton:nil
+//    otherButton:nil
+//    informativeTextWithFormat:message];
+//	[alert
+//    performSelector:@selector(runModal)
+//    onThread:[NSThread mainThread]
+//    withObject:nil
+//    waitUntilDone:NO];
+//#endif   
 }
 
 //
@@ -1136,8 +1164,6 @@ cleanup:
 {
 	@synchronized(self)
 	{
-		if (state == AS_WAITING_FOR_DATA || state == AS_STARTING_FILE_THREAD)
-			return;
 		if (audioQueue &&
 			(state == AS_PLAYING || state == AS_PAUSED ||
 				state == AS_BUFFERING || state == AS_WAITING_FOR_QUEUE_TO_START))

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -22,9 +22,7 @@
 
 NSString * const ASStatusChangedNotification = @"ASStatusChangedNotification";
 NSString * const ASPresentAlertWithTitleNotification = @"ASPresentAlertWithTitleNotification";
-#ifdef SHOUTCAST_METADATA
 NSString * const ASUpdateMetadataNotification = @"ASUpdateMetadataNotification";
-#endif
 
 NSString * const AS_NO_ERROR_STRING = @"No error.";
 NSString * const AS_FILE_STREAM_GET_PROPERTY_FAILED_STRING = @"File stream get property failed.";
@@ -218,6 +216,7 @@ void ASReadStreamCallBack
 @synthesize state;
 @synthesize bitRate;
 @synthesize httpHeaders;
+@synthesize retrieveShoutcastMetaData;
 
 //
 // initWithURL
@@ -230,9 +229,8 @@ void ASReadStreamCallBack
 	if (self != nil)
 	{
 		url = [aURL retain];
-#ifdef SHOUTCAST_METADATA
 		metaDataString = [[NSMutableString alloc] initWithString:@""];
-#endif
+      retrieveShoutcastMetaData = NO;
 	}
 	return self;
 }
@@ -246,9 +244,7 @@ void ASReadStreamCallBack
 {
 	[self stop];
 	[url release];
-#ifdef SHOUTCAST_METADATA
 	[metaDataString release];
-#endif
 	[super dealloc];
 }
 
@@ -610,9 +606,10 @@ void ASReadStreamCallBack
 		// Create the HTTP GET request
 		//
 		CFHTTPMessageRef message= CFHTTPMessageCreateRequest(NULL, (CFStringRef)@"GET", (CFURLRef)url, kCFHTTPVersion1_1);
-#ifdef SHOUTCAST_METADATA
-		CFHTTPMessageSetHeaderFieldValue(message, CFSTR("icy-metadata"), CFSTR("1"));
-#endif
+
+      if ([self retrieveShoutcastMetaData]) {
+         CFHTTPMessageSetHeaderFieldValue(message, CFSTR("icy-metadata"), CFSTR("1"));
+      }
 		//
 		// If we are creating this request to seek to a location, set the
 		// requested byte range in the headers.
@@ -1152,7 +1149,6 @@ cleanup:
 	}
 }
 
-#ifdef SHOUTCAST_METADATA
 - (void)updateMetaData:(NSString *)metaData
 {
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:metaData, @"metadata", nil];
@@ -1164,7 +1160,6 @@ cleanup:
 	[[NSNotificationCenter defaultCenter]
 	 postNotification:notification];
 }
-#endif
 
 //
 // handleReadFromStream:eventType:
@@ -1304,10 +1299,8 @@ cleanup:
 		
 		UInt8 bytes[kAQDefaultBufSize];
 		CFIndex length;
-#ifdef SHOUTCAST_METADATA
       UInt8 bytesNoMetaData[kAQDefaultBufSize];
       int lengthNoMetaData = 0;
-#endif SHOUTCAST_METADATA
 		
 		@synchronized(self)
 		{
@@ -1331,308 +1324,308 @@ cleanup:
 			{
 				return;
 			}
-#ifdef SHOUTCAST_METADATA
-			// shoutcast parsing code from http://code.google.com/p/audiostreamer-meta/
-			// with modifications by John Fricker
-			// get and handle the shoutcast metadata
-
-			int streamStart = 0;
-			if (metaDataInterval == 0)
-			{
-				CFHTTPMessageRef myResponse = (CFHTTPMessageRef)CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPResponseHeader);
-				UInt32 statusCode = CFHTTPMessageGetResponseStatusCode(myResponse);
-				
-				//CFStringRef myStatusLine = CFHTTPMessageCopyResponseStatusLine(myResponse);
-				
-				if (statusCode == 200)		// "OK" (this is true even for ICY)
-				{
-					// check if this is a ICY 200 OK response
-					NSString *icyCheck = [[[NSString alloc] initWithBytes:bytes length:10 encoding:NSUTF8StringEncoding] autorelease];
-					//NSLog(@"stream bytes %@", [NSString stringWithCString:bytes length:length]); // dataWithBytes:bytes length:1024]);
-					if (icyCheck != nil && [icyCheck caseInsensitiveCompare:@"ICY 200 OK"] == NSOrderedSame)	
-					{
-						foundIcyStart = YES;
-						//NSLog(@"ICY 200 OK");				
-					}
-					else
-					{
-						// is Live365?
-						// get all the headers
-						NSDictionary *reqHeaders = [(NSDictionary *)CFHTTPMessageCopyAllHeaderFields(myResponse) autorelease];
-						//NSLog(@"reqHeaders: %@", reqHeaders);
-						NSString *serverHeader = [reqHeaders valueForKey:@"Server"];
-						if (serverHeader != nil && NSEqualRanges([serverHeader rangeOfString:@"Nanocaster"], NSMakeRange(0, 10))) {
-							NSLog(@"Wrong stream type - can not continue to parse");
-							
-						} else {
-							// Not an ICY response
-							/*NSString *metaInt;
-							metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));	
-							metaDataInterval = [metaInt intValue];
-							[metaInt release];
-							if (metaInt)
-							{
-								parsedHeaders = YES;
-							}*/
-							NSString *metaInt;
-							NSString *contentType;
-							NSString *icyBr;
-							metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));
-							contentType = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Content-Type"));
-							icyBr = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("icy-br"));
-							/*if (contentType) 
-							{
-								// only if we haven't already set a content-type
-								if (!myData.streamContentType)
-								{
-									NSLog(@"Stream Content-Type: %@", contentType);
-									myData.streamContentType = contentType;
-									// if this is not an mp3 stream we need to restart the audio queue
-									if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
-									{
-										[myData restartAudioQueue];
-									}								
-								}
-							}*/
-							/*
-							if (bitRate == 0 && icyBr)
-							{
-								bitRate = [icyBr intValue];
-								NSLog(@"Stream Bitrate: %@", icyBr);
-								[myData updateBitrate:[icyBr intValue]];
-							}
-							*/
-							metaDataInterval = [metaInt intValue];
-							if (metaInt)
-							{
-								NSLog(@"MetaInt: %@", metaInt);
-								parsedHeaders = YES;
-							}
-						}
-					}
-				}
-				else if (statusCode == 302)
-				{
-					NSLog(@"unexpected 302");
-				}
-				else
-				{
-					// Invalid
-				}
-			} // if (metaDataInterval == 0)
-			
-			if (foundIcyStart && !foundIcyEnd)
-			{
-				char c1 = '\0';
-				char c2 = '\0';
-				char c3 = '\0';
-				char c4 = '\0';
-				int lineStart = streamStart;
-				while (YES)
-				{
-					if (streamStart + 3 > length)
-					{
-						break;
-					}
-					
-					c1 = bytes[streamStart];
-					c2 = bytes[streamStart+1];
-					c3 = bytes[streamStart+2];
-					c4 = bytes[streamStart+3];
-					
-					if (c1 == '\r' && c2 == '\n')
-					{		
-						// get the full string
-						NSString *fullString = [[[NSString alloc] initWithBytes:bytes length:streamStart encoding:NSUTF8StringEncoding] autorelease];
-						
-						// get the substring for this line
-						NSString *line = [fullString substringWithRange:NSMakeRange(lineStart, (streamStart-lineStart))];
-						//NSLog(@"Header Line: %@. Length: %d", line, [line length]);
-
-						// check if this is icy-metaint
-						NSArray *lineItems = [line componentsSeparatedByString:@":"];
-						if ([lineItems count] > 1)
-						{
-							if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-metaint"] == NSOrderedSame)
-							{
-								metaDataInterval = [[lineItems objectAtIndex:1] intValue];
-								//NSLog(@"ICY MetaInt: %d", metaDataInterval);
-							}
-						}
-/*						if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-br"] == NSOrderedSame)
-						{
-							uint32_t icybr = [[lineItems objectAtIndex:1] intValue];
-							if (bitRate == 0) {
-								bitRate = icybr;
-								NSLog(@"ICY BR: %d", icybr);
-								[myData updateBitrate:icybr];										
-							}
-						}
-						if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame)
-						{
-							NSLog(@"ICY Stream Content-Type: %@", [lineItems objectAtIndex:1]);
-							// only if we haven't already set the content type
-							if (!myData.streamContentType)
-							{
-								myData.streamContentType = [lineItems objectAtIndex:1];
-								// if this is not an mp3 stream we need to restart the audio queue
-								if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
-								{
-									[myData restartAudioQueue];
-								}										
-							}
-						}
-	*/					
-						// this is the end of a line, the new line starts in 2
-						lineStart = streamStart+2; // (c3)
-						
-						if (c3 == '\r' && c4 == '\n')
-						{
-							foundIcyEnd = YES;
-							break;
-						}
-					}
-					
-					streamStart++;
-				} // end while
-				
-				if (foundIcyEnd)
-				{
-					streamStart = streamStart + 4;
-					//NSLog(@"Found End.");	
-					parsedHeaders = YES;
-				}
-			}
-			
-			if (parsedHeaders)
-			{
-				// look at each byte
-				for (int i=streamStart; i < length; i++)
-				{
-					// is this a metadata byte?
-					if (metaDataBytesRemaining > 0)
-					{
-						//NSLog(@"meta: %C", bytes[i]);
-						[metaDataString appendFormat:@"%C", bytes[i]];
-						
-						metaDataBytesRemaining -= 1;
-						
-						if (metaDataBytesRemaining == 0)
-						{
-							[self updateMetaData:metaDataString];
-							
-							dataBytesRead = 0;
-						}
-						continue;
-					}
-					
-					// is this the interval byte?
-					if (metaDataInterval > 0 && dataBytesRead == metaDataInterval)
-					{
-						metaDataBytesRemaining = bytes[i] * 16;
-						//NSLog(@"Found interval. Interval: %d, Meta Length: %d", metaDataInterval, metaDataBytesRemaining);
-
-						[metaDataString setString:@""];
-						
-						if (metaDataBytesRemaining == 0)
-						{
-							dataBytesRead = 0;
-						}
-						else
-						{
-							// NOOP
-							//NSLog(@"Found interval. Meta bytes remaining: %d", metaDataBytesRemaining);
-						}
-						
-						continue;
-					}
-					
-					// this is a data byte
-					dataBytesRead += 1;
-					
-					// copy the data to the new buffer
-					bytesNoMetaData[lengthNoMetaData] = bytes[i];
-					lengthNoMetaData += 1;
-				} // end for
-				
-				// pthread_mutex_unlock(&mutexMeta);
-			}	// end if parsedHeaders
-#endif
+         if ([self retrieveShoutcastMetaData]) {
+            // shoutcast parsing code from http://code.google.com/p/audiostreamer-meta/
+            // with modifications by John Fricker
+            // get and handle the shoutcast metadata
+            
+            int streamStart = 0;
+            if (metaDataInterval == 0)
+            {
+               CFHTTPMessageRef myResponse = (CFHTTPMessageRef)CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPResponseHeader);
+               UInt32 statusCode = CFHTTPMessageGetResponseStatusCode(myResponse);
+               
+               //CFStringRef myStatusLine = CFHTTPMessageCopyResponseStatusLine(myResponse);
+               
+               if (statusCode == 200)		// "OK" (this is true even for ICY)
+               {
+                  // check if this is a ICY 200 OK response
+                  NSString *icyCheck = [[[NSString alloc] initWithBytes:bytes length:10 encoding:NSUTF8StringEncoding] autorelease];
+                  //NSLog(@"stream bytes %@", [NSString stringWithCString:bytes length:length]); // dataWithBytes:bytes length:1024]);
+                  if (icyCheck != nil && [icyCheck caseInsensitiveCompare:@"ICY 200 OK"] == NSOrderedSame)	
+                  {
+                     foundIcyStart = YES;
+                     //NSLog(@"ICY 200 OK");				
+                  }
+                  else
+                  {
+                     // is Live365?
+                     // get all the headers
+                     NSDictionary *reqHeaders = [(NSDictionary *)CFHTTPMessageCopyAllHeaderFields(myResponse) autorelease];
+                     //NSLog(@"reqHeaders: %@", reqHeaders);
+                     NSString *serverHeader = [reqHeaders valueForKey:@"Server"];
+                     if (serverHeader != nil && NSEqualRanges([serverHeader rangeOfString:@"Nanocaster"], NSMakeRange(0, 10))) {
+                        NSLog(@"Wrong stream type - can not continue to parse");
+                        
+                     } else {
+                        // Not an ICY response
+                        /*NSString *metaInt;
+                         metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));	
+                         metaDataInterval = [metaInt intValue];
+                         [metaInt release];
+                         if (metaInt)
+                         {
+                         parsedHeaders = YES;
+                         }*/
+                        NSString *metaInt;
+                        NSString *contentType;
+                        NSString *icyBr;
+                        metaInt = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Icy-Metaint"));
+                        contentType = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("Content-Type"));
+                        icyBr = (NSString *) CFHTTPMessageCopyHeaderFieldValue(myResponse, CFSTR("icy-br"));
+                        /*if (contentType) 
+                         {
+                         // only if we haven't already set a content-type
+                         if (!myData.streamContentType)
+                         {
+                         NSLog(@"Stream Content-Type: %@", contentType);
+                         myData.streamContentType = contentType;
+                         // if this is not an mp3 stream we need to restart the audio queue
+                         if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
+                         {
+                         [myData restartAudioQueue];
+                         }								
+                         }
+                         }*/
+                        /*
+                         if (bitRate == 0 && icyBr)
+                         {
+                         bitRate = [icyBr intValue];
+                         NSLog(@"Stream Bitrate: %@", icyBr);
+                         [myData updateBitrate:[icyBr intValue]];
+                         }
+                         */
+                        metaDataInterval = [metaInt intValue];
+                        if (metaInt)
+                        {
+                           NSLog(@"MetaInt: %@", metaInt);
+                           parsedHeaders = YES;
+                        }
+                     }
+                  }
+               }
+               else if (statusCode == 302)
+               {
+                  NSLog(@"unexpected 302");
+               }
+               else
+               {
+                  // Invalid
+               }
+            } // if (metaDataInterval == 0)
+            
+            if (foundIcyStart && !foundIcyEnd)
+            {
+               char c1 = '\0';
+               char c2 = '\0';
+               char c3 = '\0';
+               char c4 = '\0';
+               int lineStart = streamStart;
+               while (YES)
+               {
+                  if (streamStart + 3 > length)
+                  {
+                     break;
+                  }
+                  
+                  c1 = bytes[streamStart];
+                  c2 = bytes[streamStart+1];
+                  c3 = bytes[streamStart+2];
+                  c4 = bytes[streamStart+3];
+                  
+                  if (c1 == '\r' && c2 == '\n')
+                  {		
+                     // get the full string
+                     NSString *fullString = [[[NSString alloc] initWithBytes:bytes length:streamStart encoding:NSUTF8StringEncoding] autorelease];
+                     
+                     // get the substring for this line
+                     NSString *line = [fullString substringWithRange:NSMakeRange(lineStart, (streamStart-lineStart))];
+                     //NSLog(@"Header Line: %@. Length: %d", line, [line length]);
+                     
+                     // check if this is icy-metaint
+                     NSArray *lineItems = [line componentsSeparatedByString:@":"];
+                     if ([lineItems count] > 1)
+                     {
+                        if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-metaint"] == NSOrderedSame)
+                        {
+                           metaDataInterval = [[lineItems objectAtIndex:1] intValue];
+                           //NSLog(@"ICY MetaInt: %d", metaDataInterval);
+                        }
+                     }
+                     /*						if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"icy-br"] == NSOrderedSame)
+                      {
+                      uint32_t icybr = [[lineItems objectAtIndex:1] intValue];
+                      if (bitRate == 0) {
+                      bitRate = icybr;
+                      NSLog(@"ICY BR: %d", icybr);
+                      [myData updateBitrate:icybr];										
+                      }
+                      }
+                      if ([[lineItems objectAtIndex:0] caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame)
+                      {
+                      NSLog(@"ICY Stream Content-Type: %@", [lineItems objectAtIndex:1]);
+                      // only if we haven't already set the content type
+                      if (!myData.streamContentType)
+                      {
+                      myData.streamContentType = [lineItems objectAtIndex:1];
+                      // if this is not an mp3 stream we need to restart the audio queue
+                      if ([myData.streamContentType caseInsensitiveCompare:@"audio/mpeg"] != NSOrderedSame)
+                      {
+                      [myData restartAudioQueue];
+                      }										
+                      }
+                      }
+                      */					
+                     // this is the end of a line, the new line starts in 2
+                     lineStart = streamStart+2; // (c3)
+                     
+                     if (c3 == '\r' && c4 == '\n')
+                     {
+                        foundIcyEnd = YES;
+                        break;
+                     }
+                  }
+                  
+                  streamStart++;
+               } // end while
+               
+               if (foundIcyEnd)
+               {
+                  streamStart = streamStart + 4;
+                  //NSLog(@"Found End.");	
+                  parsedHeaders = YES;
+               }
+            }
+            
+            if (parsedHeaders)
+            {
+               // look at each byte
+               for (int i=streamStart; i < length; i++)
+               {
+                  // is this a metadata byte?
+                  if (metaDataBytesRemaining > 0)
+                  {
+                     //NSLog(@"meta: %C", bytes[i]);
+                     [metaDataString appendFormat:@"%C", bytes[i]];
+                     
+                     metaDataBytesRemaining -= 1;
+                     
+                     if (metaDataBytesRemaining == 0)
+                     {
+                        [self updateMetaData:metaDataString];
+                        
+                        dataBytesRead = 0;
+                     }
+                     continue;
+                  }
+                  
+                  // is this the interval byte?
+                  if (metaDataInterval > 0 && dataBytesRead == metaDataInterval)
+                  {
+                     metaDataBytesRemaining = bytes[i] * 16;
+                     //NSLog(@"Found interval. Interval: %d, Meta Length: %d", metaDataInterval, metaDataBytesRemaining);
+                     
+                     [metaDataString setString:@""];
+                     
+                     if (metaDataBytesRemaining == 0)
+                     {
+                        dataBytesRead = 0;
+                     }
+                     else
+                     {
+                        // NOOP
+                        //NSLog(@"Found interval. Meta bytes remaining: %d", metaDataBytesRemaining);
+                     }
+                     
+                     continue;
+                  }
+                  
+                  // this is a data byte
+                  dataBytesRead += 1;
+                  
+                  // copy the data to the new buffer
+                  bytesNoMetaData[lengthNoMetaData] = bytes[i];
+                  lengthNoMetaData += 1;
+               } // end for
+               
+               // pthread_mutex_unlock(&mutexMeta);
+            }	// end if parsedHeaders
+         }
 		}
-#ifdef SHOUTCAST_METADATA
-		if (discontinuous)
-		{
-			/*
-			 * SHOUTcast can send the interval byte by itself. In that case lengthNoMetaData is 0, but
-			 * the interval byte should not be sent to the audio queue. The check for a metaDataInterval == 0
-			 * will make sure that we don't ever send in the interval byte on a stream with metadata
-			 */
-			
-			if (lengthNoMetaData > 0)
-			{
-				//NSLog(@"Parsing no meta bytes (Discontinuous).");
-				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, kAudioFileStreamParseFlag_Discontinuity);
-				if (err)
-				{
-					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-					return;
-				}			
-			}
-			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
-			{
-				//NSLog(@"Parsing normal bytes (Discontinuous).");
-				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
-				if (err)
-				{
-					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-					return;
-				}
-			}
+      if ([self retrieveShoutcastMetaData]) {
+         if (discontinuous)
+         {
+            /*
+             * SHOUTcast can send the interval byte by itself. In that case lengthNoMetaData is 0, but
+             * the interval byte should not be sent to the audio queue. The check for a metaDataInterval == 0
+             * will make sure that we don't ever send in the interval byte on a stream with metadata
+             */
+            
+            if (lengthNoMetaData > 0)
+            {
+               //NSLog(@"Parsing no meta bytes (Discontinuous).");
+               err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, kAudioFileStreamParseFlag_Discontinuity);
+               if (err)
+               {
+                  [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+                  return;
+               }			
+            }
+            else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
+            {
+               //NSLog(@"Parsing normal bytes (Discontinuous).");
+               err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
+               if (err)
+               {
+                  [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+                  return;
+               }
+            }
+         }
+         else
+         {
+            if (lengthNoMetaData > 0)
+            {
+               //NSLog(@"Parsing no meta bytes.");
+               err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, 0);
+               if (err)
+               {
+                  [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+                  return;
+               }
+            }
+            else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
+            {
+               //NSLog(@"Parsing normal bytes.");
+               err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
+               if (err)
+               {
+                  [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+                  return;
+               }
+            }
+         } // end discontinuous [self retrieveShoutcastMetaData] == YES
 		}
-		else
-		{
-			if (lengthNoMetaData > 0)
-			{
-				//NSLog(@"Parsing no meta bytes.");
-				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, 0);
-				if (err)
-				{
-					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-					return;
-				}
-			}
-			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
-			{
-				//NSLog(@"Parsing normal bytes.");
-				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
-				if (err)
-				{
-					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-					return;
-				}
-			}
-		} // end discontinuous
-		
-#else
-		if (discontinuous)
-		{
-			err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
-			if (err)
-			{
-				[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-				return;
-			}
-		}
-		else
-		{
-			err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
-			if (err)
-			{
-				[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
-				return;
-			}
-		}
-#endif
+      else { // [self retrieveShoutcastMetaData] == NO
+         if (discontinuous)
+         {
+            err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
+            if (err)
+            {
+               [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+               return;
+            }
+         }
+         else
+         {
+            err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
+            if (err)
+            {
+               [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
+               return;
+            }
+         }
+      }
 	}
 }
 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -13,7 +13,7 @@
 //
 
 #import "AudioStreamer.h"
-#ifdef TARGET_OS_IPHONE			
+#if TARGET_OS_IPHONE			
 #import <CFNetwork/CFNetwork.h>
 #endif
 
@@ -60,7 +60,7 @@ NSString * const AS_AUDIO_BUFFER_TOO_SMALL_STRING = @"Audio packets are larger t
 - (void)handlePropertyChangeForQueue:(AudioQueueRef)inAQ
 	propertyID:(AudioQueuePropertyID)inID;
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 - (void)handleInterruptionChangeToState:(AudioQueuePropertyID)inInterruptionState;
 #endif
 
@@ -86,7 +86,7 @@ void MyPacketsProc(				void *							inClientData,
 								AudioStreamPacketDescription	*inPacketDescriptions);
 OSStatus MyEnqueueBuffer(AudioStreamer* myData);
 
-#ifdef TARGET_OS_IPHONE			
+#if TARGET_OS_IPHONE			
 void MyAudioSessionInterruptionListener(void *inClientData, UInt32 inInterruptionState);
 #endif
 
@@ -174,7 +174,7 @@ void MyAudioQueueIsRunningCallback(void *inUserData, AudioQueueRef inAQ, AudioQu
 	[streamer handlePropertyChangeForQueue:inAQ propertyID:inID];
 }
 
-#ifdef TARGET_OS_IPHONE			
+#if TARGET_OS_IPHONE			
 //
 // MyAudioSessionInterruptionListener
 //
@@ -359,7 +359,7 @@ void ASReadStreamCallBack
 //
 - (void)presentAlertWithTitle:(NSString*)title message:(NSString*)message
 {
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 	UIAlertView *alert = [
 		[[UIAlertView alloc]
 			initWithTitle:title
@@ -743,7 +743,7 @@ void ASReadStreamCallBack
 			return;
 		}
 		
-	#ifdef TARGET_OS_IPHONE			
+	#if TARGET_OS_IPHONE			
 		//
 		// Set the audio session category so that we continue to play if the
 		// iPhone/iPod auto-locks.
@@ -850,7 +850,7 @@ cleanup:
 		pthread_mutex_destroy(&queueBuffersMutex);
 		pthread_cond_destroy(&queueBufferReadyCondition);
 
-#ifdef TARGET_OS_IPHONE			
+#if TARGET_OS_IPHONE			
 		AudioSessionSetActive(false);
 #endif
 
@@ -1911,7 +1911,7 @@ cleanup:
 	[pool release];
 }
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 //
 // handleInterruptionChangeForQueue:propertyID:
 //

--- a/Classes/LevelMeterView.h
+++ b/Classes/LevelMeterView.h
@@ -1,0 +1,30 @@
+//
+//  LevelMeterView.h
+//  iPhoneStreamingPlayer
+//
+//  Created by Carlos Oliva G. on 07-08-10.
+//  Copyright 2010 iDev Software. All rights reserved.
+//
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <Cocoa/Cocoa.h>
+#endif
+
+
+
+#if TARGET_OS_IPHONE
+@interface LevelMeterView : UIView 
+#else
+@interface LevelMeterView : NSView 
+#endif
+{
+	CGFloat leftValue;
+	CGFloat rightValue;
+}
+
+- (void)updateMeterWithLeftValue:(CGFloat)left rightValue:(CGFloat)right;
+
+
+@end

--- a/Classes/LevelMeterView.m
+++ b/Classes/LevelMeterView.m
@@ -1,0 +1,106 @@
+//
+//  LevelMeterView.m
+//  iPhoneStreamingPlayer
+//
+//  Created by Carlos Oliva G. on 07-08-10.
+//  Copyright 2010 iDev Software. All rights reserved.
+//
+
+#import "LevelMeterView.h"
+
+#define kMeterViewFullWidth 275.0
+
+
+@implementation LevelMeterView
+
+
+- (id)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        // Initialization code
+#if TARGET_OS_IPHONE
+		self.backgroundColor = [UIColor blackColor];
+#endif
+    }
+    return self;
+}
+
+// Only override drawRect: if you perform custom drawing.
+// An empty implementation adversely affects performance during animation.
+#if TARGET_OS_IPHONE
+- (void)drawRect:(CGRect)rect {
+    // Drawing code
+	[[UIColor whiteColor] set];
+	[@"L" drawInRect:CGRectMake(0.0, 10.0, 15.0, 15.0) withFont:[UIFont boldSystemFontOfSize:[UIFont systemFontSize]] lineBreakMode:UILineBreakModeWordWrap alignment:UITextAlignmentCenter];
+	[@"R" drawInRect:CGRectMake(0.0, 35.0, 15.0, 15.0) withFont:[UIFont boldSystemFontOfSize:[UIFont systemFontSize]] lineBreakMode:UILineBreakModeWordWrap alignment:UITextAlignmentCenter];
+	
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	CGContextSetFillColorWithColor(context, [UIColor greenColor].CGColor);
+	CGContextFillRect(context, CGRectMake(15.0, 10.0, kMeterViewFullWidth * leftValue, 15.0));
+	CGContextFillRect(context, CGRectMake(15.0, 35.0, kMeterViewFullWidth * rightValue, 15.0));
+	CGContextFlush(context);
+}
+#else
+static CGColorRef CGColorCreateFromNSColor (CGColorSpaceRef colorSpace, NSColor *color)
+{
+   NSColor *deviceColor = [color colorUsingColorSpaceName:NSDeviceRGBColorSpace];
+   
+   CGFloat components[4];
+   [deviceColor getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+   
+   return CGColorCreate (colorSpace, components);
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+   // Draw the background color.
+   [[NSColor blackColor] setFill];
+   NSRectFill(dirtyRect);
+   
+   // Draw the text labels.
+   NSDictionary *attribDict = 
+   [NSDictionary dictionaryWithObjectsAndKeys: 
+    [NSColor whiteColor], NSForegroundColorAttributeName, 
+    [NSFont systemFontOfSize:14], NSFontAttributeName, 
+    nil];
+	
+   [@"L" drawInRect:CGRectMake(0.0, 35.0, 15.0, 15.0) withAttributes:attribDict];
+   [@"R" drawInRect:CGRectMake(0.0, 10.0, 15.0, 15.0) withAttributes:attribDict];
+   
+   // Draw the level meter.
+   CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
+   CGContextSaveGState(context);
+   
+   NSColor *nsColor = [NSColor greenColor];
+   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB ();
+   CGColorRef color = CGColorCreateFromNSColor (colorSpace, nsColor);
+   CGColorSpaceRelease (colorSpace);
+   
+	CGContextSetFillColorWithColor(context, color);
+	CGContextFillRect(context, CGRectMake(15.0, 35.0, kMeterViewFullWidth * leftValue, 15.0));
+	CGContextFillRect(context, CGRectMake(15.0, 10.0, kMeterViewFullWidth * rightValue, 15.0));
+	CGContextFlush(context);
+   
+   CGColorRelease(color);
+   
+   CGContextRestoreGState(context);
+
+}
+#endif
+
+
+- (void)updateMeterWithLeftValue:(CGFloat)left rightValue:(CGFloat)right {
+	leftValue = left;
+	rightValue = right;
+#if TARGET_OS_IPHONE
+	[self setNeedsDisplay];
+#else
+	[self setNeedsDisplay:YES];
+#endif
+}
+
+- (void)dealloc {
+    [super dealloc];
+}
+
+
+@end

--- a/Classes/LevelMeterView.m
+++ b/Classes/LevelMeterView.m
@@ -14,15 +14,15 @@
 @implementation LevelMeterView
 
 
+#if TARGET_OS_IPHONE
 - (id)initWithFrame:(CGRect)frame {
     if ((self = [super initWithFrame:frame])) {
         // Initialization code
-#if TARGET_OS_IPHONE
 		self.backgroundColor = [UIColor blackColor];
-#endif
     }
     return self;
 }
+#endif
 
 // Only override drawRect: if you perform custom drawing.
 // An empty implementation adversely affects performance during animation.
@@ -63,8 +63,8 @@ static CGColorRef CGColorCreateFromNSColor (CGColorSpaceRef colorSpace, NSColor 
     [NSFont systemFontOfSize:14], NSFontAttributeName, 
     nil];
 	
-   [@"L" drawInRect:CGRectMake(0.0, 35.0, 15.0, 15.0) withAttributes:attribDict];
-   [@"R" drawInRect:CGRectMake(0.0, 10.0, 15.0, 15.0) withAttributes:attribDict];
+   [@"L" drawInRect:NSRectFromCGRect(CGRectMake(0.0, 35.0, 15.0, 15.0)) withAttributes:attribDict];
+   [@"R" drawInRect:NSRectFromCGRect(CGRectMake(0.0, 10.0, 15.0, 15.0)) withAttributes:attribDict];
    
    // Draw the level meter.
    CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];

--- a/Classes/MacStreamingPlayerController.h
+++ b/Classes/MacStreamingPlayerController.h
@@ -24,6 +24,7 @@
 #import <Cocoa/Cocoa.h>
 
 @class AudioStreamer;
+@class LevelMeterView;
 
 @interface MacStreamingPlayerController : NSObject
 {
@@ -33,6 +34,8 @@
 	IBOutlet NSSlider *progressSlider;
 	AudioStreamer *streamer;
 	NSTimer *progressUpdateTimer;
+	NSTimer *levelMeterUpdateTimer;
+	IBOutlet LevelMeterView *levelMeterView;
 }
 
 - (IBAction)buttonPressed:(id)sender;

--- a/Classes/MacStreamingPlayerController.m
+++ b/Classes/MacStreamingPlayerController.m
@@ -29,7 +29,7 @@
 
 - (void)awakeFromNib
 {
-	[downloadSourceField setStringValue:@"http://192.168.1.2/~matt/inside.m4a"];
+	[downloadSourceField setStringValue:@"http://shoutmedia.abc.net.au:10326"];
 }
 
 //

--- a/Classes/iPhoneStreamingPlayerAppDelegate.h
+++ b/Classes/iPhoneStreamingPlayerAppDelegate.h
@@ -19,10 +19,11 @@
 @interface iPhoneStreamingPlayerAppDelegate : NSObject <UIApplicationDelegate> {
     UIWindow *window;
     iPhoneStreamingPlayerViewController *viewController;
+	BOOL uiIsVisible;
 }
 
 @property (nonatomic, retain) IBOutlet UIWindow *window;
 @property (nonatomic, retain) IBOutlet iPhoneStreamingPlayerViewController *viewController;
-
+@property (nonatomic) BOOL uiIsVisible;
 @end
 

--- a/Classes/iPhoneStreamingPlayerAppDelegate.m
+++ b/Classes/iPhoneStreamingPlayerAppDelegate.m
@@ -14,13 +14,16 @@
 
 #import "iPhoneStreamingPlayerAppDelegate.h"
 #import "iPhoneStreamingPlayerViewController.h"
+#import "AudioStreamer.h"
 
 @implementation iPhoneStreamingPlayerAppDelegate
 
 @synthesize window;
 @synthesize viewController;
 
-- (void)applicationDidFinishLaunching:(UIApplication *)application {
+@synthesize uiIsVisible;
+
+- (void)applicationDidFinishLaunching:(UIApplication *)application {    
     // Override point for customization after app launch    
     [window addSubview:viewController.view];
     [window makeKeyAndVisible];
@@ -33,6 +36,92 @@
     [viewController release];
     [window release];
     [super dealloc];
+}
+
+- (void)presentAlertWithTitle:(NSNotification *)notification
+{
+	if (!uiIsVisible)
+		return;
+	NSString *title = [[notification userInfo] objectForKey:@"title"];
+	NSString *message = [[notification userInfo] objectForKey:@"message"];
+#ifdef TARGET_OS_IPHONE
+	UIAlertView *alert = [
+						  [[UIAlertView alloc]
+						   initWithTitle:title
+						   message:message
+						   delegate:self
+						   cancelButtonTitle:NSLocalizedString(@"OK", @"")
+						   otherButtonTitles: nil]
+						  autorelease];
+	[alert
+	 performSelector:@selector(show)
+	 onThread:[NSThread mainThread]
+	 withObject:nil
+	 waitUntilDone:NO];
+#else
+	NSAlert *alert =
+	[NSAlert
+	 alertWithMessageText:title
+	 defaultButton:NSLocalizedString(@"OK", @"")
+	 alternateButton:nil
+	 otherButton:nil
+	 informativeTextWithFormat:message];
+	[alert
+	 performSelector:@selector(runModal)
+	 onThread:[NSThread mainThread]
+	 withObject:nil
+	 waitUntilDone:NO];
+#endif
+}
+- (void)applicationWillResignActive:(UIApplication *)application {
+    /*
+     Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+     Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+     */
+	self.uiIsVisible = NO;
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    /*
+     Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+     If your application supports background execution, called instead of applicationWillTerminate: when the user quits.
+     */
+	self.uiIsVisible = NO;
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    /*
+     Called as part of  transition from the background to the inactive state: here you can undo many of the changes made on entering the background.
+     */
+	self.uiIsVisible = YES;
+	[[NSNotificationCenter defaultCenter]
+	 addObserver:self
+	 selector:@selector(presentAlertWithTitle:)
+	 name:ASPresentAlertWithTitleNotification
+	 object:nil];
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    /*
+     Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+     */
+	self.uiIsVisible = YES;
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    /*
+     Called when the application is about to terminate.
+     See also applicationDidEnterBackground:.
+     */
+	self.uiIsVisible = NO;
+	[[NSNotificationCenter defaultCenter]
+	 removeObserver:self
+	 name:ASPresentAlertWithTitleNotification
+	 object:nil];
 }
 
 

--- a/Classes/iPhoneStreamingPlayerViewController.h
+++ b/Classes/iPhoneStreamingPlayerViewController.h
@@ -23,6 +23,8 @@
 	IBOutlet UIView *volumeSlider;
 	IBOutlet UILabel *positionLabel;
 	IBOutlet UISlider *progressSlider;
+	IBOutlet UITextField *metadataArtist;
+	IBOutlet UITextField *metadataTitle;
 	AudioStreamer *streamer;
 	NSTimer *progressUpdateTimer;
 }

--- a/Classes/iPhoneStreamingPlayerViewController.h
+++ b/Classes/iPhoneStreamingPlayerViewController.h
@@ -24,6 +24,7 @@
 #import <UIKit/UIKit.h>
 
 @class AudioStreamer;
+@class LevelMeterView;
 
 @interface iPhoneStreamingPlayerViewController : UIViewController
 {
@@ -36,6 +37,8 @@
 	IBOutlet UITextField *metadataTitle;
 	AudioStreamer *streamer;
 	NSTimer *progressUpdateTimer;
+	NSTimer *levelMeterUpdateTimer;
+	LevelMeterView *levelMeterView;
 }
 
 - (IBAction)buttonPressed:(id)sender;

--- a/Classes/iPhoneStreamingPlayerViewController.m
+++ b/Classes/iPhoneStreamingPlayerViewController.m
@@ -110,13 +110,14 @@
 		selector:@selector(playbackStateChanged:)
 		name:ASStatusChangedNotification
 		object:streamer];
-#ifdef SHOUTCAST_METADATA
+
+   // Enable shoutcast metadata retrieval.
+   [streamer setRetrieveShoutcastMetaData:YES];
 	[[NSNotificationCenter defaultCenter]
 	 addObserver:self
 	 selector:@selector(metadataChanged:)
 	 name:ASUpdateMetadataNotification
 	 object:streamer];
-#endif
 }
 
 //
@@ -268,7 +269,6 @@
 	}
 }
 
-#ifdef SHOUTCAST_METADATA
 /** Example metadata
  * 
  StreamTitle='Kim Sozzi / Amuka / Livvi Franc - Secret Love / It's Over / Automatik',
@@ -315,7 +315,6 @@
 		metadataTitle.text = streamTitle;
 	}
 }
-#endif
 
 //
 // updateProgress:

--- a/English.lproj/MainMenu.xib
+++ b/English.lproj/MainMenu.xib
@@ -2,17 +2,28 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">10J869</string>
-		<string key="IBDocument.InterfaceBuilderVersion">851</string>
+		<string key="IBDocument.SystemVersion">10J567</string>
+		<string key="IBDocument.InterfaceBuilderVersion">1305</string>
 		<string key="IBDocument.AppKitVersion">1038.35</string>
-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<string key="IBDocument.HIToolboxVersion">462.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">851</string>
+			<string key="NS.object.0">1305</string>
 		</object>
-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<integer value="372"/>
+			<string>NSMenuItem</string>
+			<string>NSMenu</string>
+			<string>NSTextFieldCell</string>
+			<string>NSButtonCell</string>
+			<string>NSButton</string>
+			<string>NSSlider</string>
+			<string>NSSliderCell</string>
+			<string>NSCustomObject</string>
+			<string>NSCustomView</string>
+			<string>NSView</string>
+			<string>NSWindowTemplate</string>
+			<string>NSTextField</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -1111,12 +1122,11 @@
 			<object class="NSWindowTemplate" id="972006081">
 				<int key="NSWindowStyleMask">15</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{335, 728}, {470, 144}}</string>
+				<string key="NSWindowRect">{{335, 728}, {470, 204}}</string>
 				<int key="NSWTFlags">1946157056</int>
 				<string key="NSWindowTitle">Window</string>
 				<string key="NSWindowClass">NSWindow</string>
 				<nil key="NSViewClass"/>
-				<string key="NSWindowContentMaxSize">{1.79769e+308, 1.79769e+308}</string>
 				<string key="NSWindowContentMinSize">{470, 104}</string>
 				<object class="NSView" key="NSWindowView" id="439893737">
 					<reference key="NSNextResponder"/>
@@ -1126,8 +1136,10 @@
 						<object class="NSButton" id="465513208">
 							<reference key="NSNextResponder" ref="439893737"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{5, 53}, {80, 80}}</string>
+							<string key="NSFrame">{{5, 113}, {80, 80}}</string>
 							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="1038344492"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="890323195">
@@ -1155,8 +1167,10 @@
 						<object class="NSTextField" id="997363787">
 							<reference key="NSNextResponder" ref="439893737"/>
 							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{93, 77}, {357, 22}}</string>
+							<string key="NSFrame">{{93, 137}, {357, 22}}</string>
 							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="661414436"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="250554935">
@@ -1189,8 +1203,10 @@
 						<object class="NSTextField" id="1038344492">
 							<reference key="NSNextResponder" ref="439893737"/>
 							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{93, 106}, {357, 18}}</string>
+							<string key="NSFrame">{{93, 166}, {357, 18}}</string>
 							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="997363787"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="163232485">
@@ -1219,8 +1235,10 @@
 						<object class="NSTextField" id="661414436">
 							<reference key="NSNextResponder" ref="439893737"/>
 							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{93, 52}, {357, 17}}</string>
+							<string key="NSFrame">{{93, 112}, {357, 17}}</string>
 							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="856524559"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="40329830">
@@ -1237,8 +1255,10 @@
 						<object class="NSSlider" id="856524559">
 							<reference key="NSNextResponder" ref="439893737"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{91, 18}, {361, 26}}</string>
+							<string key="NSFrame">{{91, 78}, {361, 26}}</string>
 							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="457301242"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSSliderCell" key="NSCell" id="259515591">
@@ -1256,15 +1276,27 @@
 								<bool key="NSVertical">NO</bool>
 							</object>
 						</object>
+						<object class="NSCustomView" id="457301242">
+							<reference key="NSNextResponder" ref="439893737"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{93, 12}, {357, 60}}</string>
+							<reference key="NSSuperview" ref="439893737"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
+							<int key="NSViewLayerContentsRedrawPolicy">2</int>
+							<string key="NSClassName">LevelMeterView</string>
+						</object>
 					</object>
-					<string key="NSFrameSize">{470, 144}</string>
+					<string key="NSFrame">{{7, 11}, {470, 204}}</string>
 					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="465513208"/>
 					<bool key="NSViewIsLayerTreeHost">YES</bool>
 					<int key="NSViewLayerContentsRedrawPolicy">2</int>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
 				<string key="NSMinSize">{470, 126}</string>
-				<string key="NSMaxSize">{1.79769e+308, 1.79769e+308}</string>
+				<string key="NSMaxSize">{1e+13, 1e+13}</string>
 			</object>
 			<object class="NSCustomObject" id="755631768">
 				<string key="NSClassName">NSFontManager</string>
@@ -1860,6 +1892,14 @@
 					</object>
 					<int key="connectionID">471</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">levelMeterView</string>
+						<reference key="source" ref="149200707"/>
+						<reference key="destination" ref="457301242"/>
+					</object>
+					<int key="connectionID">473</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -2451,6 +2491,7 @@
 							<reference ref="661414436"/>
 							<reference ref="1038344492"/>
 							<reference ref="856524559"/>
+							<reference ref="457301242"/>
 						</object>
 						<reference key="parent" ref="972006081"/>
 					</object>
@@ -2840,6 +2881,11 @@
 						<reference key="object" ref="259515591"/>
 						<reference key="parent" ref="856524559"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">472</int>
+						<reference key="object" ref="457301242"/>
+						<reference key="parent" ref="439893737"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -2981,10 +3027,6 @@
 					<string>371.IBWindowTemplateEditedContentRect</string>
 					<string>371.NSWindowTemplate.visibleAtLaunch</string>
 					<string>371.editorWindowContentRectSynchronizationRect</string>
-					<string>371.windowTemplate.hasMaxSize</string>
-					<string>371.windowTemplate.hasMinSize</string>
-					<string>371.windowTemplate.maxSize</string>
-					<string>371.windowTemplate.minSize</string>
 					<string>372.IBPluginDependency</string>
 					<string>375.IBPluginDependency</string>
 					<string>376.IBEditorWindowLastContentRect</string>
@@ -3043,6 +3085,7 @@
 					<string>463.IBPluginDependency</string>
 					<string>468.IBPluginDependency</string>
 					<string>469.IBPluginDependency</string>
+					<string>472.IBPluginDependency</string>
 					<string>5.IBPluginDependency</string>
 					<string>5.ImportedFromIB2</string>
 					<string>56.IBPluginDependency</string>
@@ -3216,10 +3259,6 @@
 					<string>{{76, 490}, {470, 144}}</string>
 					<integer value="1"/>
 					<string>{{33, 99}, {480, 360}}</string>
-					<boolean value="NO"/>
-					<boolean value="YES"/>
-					<string>{1024, 104}</string>
-					<string>{470, 104}</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>{{437, 242}, {86, 43}}</string>
@@ -3236,6 +3275,7 @@
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>{{523, 2}, {178, 283}}</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -3318,24 +3358,28 @@
 			<object class="NSMutableDictionary" key="unlocalizedProperties">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="activeLocalization"/>
 			<object class="NSMutableDictionary" key="localizations">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">471</int>
+			<int key="maxID">473</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
 				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">LevelMeterView</string>
+					<string key="superclassName">NSView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/LevelMeterView.h</string>
+					</object>
+				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">MacStreamingPlayerController</string>
 					<string key="superclassName">NSObject</string>
@@ -3377,6 +3421,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>button</string>
 							<string>downloadSourceField</string>
+							<string>levelMeterView</string>
 							<string>positionLabel</string>
 							<string>progressSlider</string>
 						</object>
@@ -3384,6 +3429,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>NSButton</string>
 							<string>NSTextField</string>
+							<string>LevelMeterView</string>
 							<string>NSTextField</string>
 							<string>NSSlider</string>
 						</object>
@@ -3394,6 +3440,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>button</string>
 							<string>downloadSourceField</string>
+							<string>levelMeterView</string>
 							<string>positionLabel</string>
 							<string>progressSlider</string>
 						</object>
@@ -3408,6 +3455,10 @@
 								<string key="candidateClassName">NSTextField</string>
 							</object>
 							<object class="IBToOneOutletInfo">
+								<string key="name">levelMeterView</string>
+								<string key="candidateClassName">LevelMeterView</string>
+							</object>
+							<object class="IBToOneOutletInfo">
 								<string key="name">positionLabel</string>
 								<string key="candidateClassName">NSTextField</string>
 							</object>
@@ -3419,106 +3470,11 @@
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/MacStreamingPlayerController.h</string>
-					</object>
-				</object>
-			</object>
-			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSActionCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="963752350">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="198198207">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSApplicationScripting.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="390396171">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSColorPanel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSHelpManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPageLayout.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSUserInterfaceItemSearching.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSBrowser</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSBrowser.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButton</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButtonCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSCell</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSControl</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="266226690">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
+						<string key="minorKey">./Classes/MacStreamingPlayerController.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">NSDocument</string>
-					<string key="superclassName">NSObject</string>
 					<object class="NSMutableDictionary" key="actions">
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
@@ -3580,492 +3536,8 @@
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDocument.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSDocument</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDocumentScripting.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSDocumentController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>clearRecentDocuments:</string>
-							<string>newDocument:</string>
-							<string>openDocument:</string>
-							<string>saveAllDocuments:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>clearRecentDocuments:</string>
-							<string>newDocument:</string>
-							<string>openDocument:</string>
-							<string>saveAllDocuments:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">clearRecentDocuments:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">newDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">openDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveAllDocuments:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDocumentController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFontManager</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="85258297">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSFontManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFormatter</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMatrix</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMatrix.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenu</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="589357531">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenuItem</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="287996405">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenuItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMovieView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMovieView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSAccessibility.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="963752350"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="198198207"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="390396171"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="266226690"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDictionaryController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDragging.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="85258297"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSFontPanel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSKeyValueBinding.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<reference key="sourceIdentifier" ref="589357531"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSNibLoading.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSOutlineView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPasteboard.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSavePanel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="541644174">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTableView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSToolbarItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="721605179">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSArchiver.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSClassDescription.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSObjectScripting.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSPortCoder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSScriptClassDescription.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSScriptKeyValueCoding.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSScriptObjectSpecifiers.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSScriptWhoseTests.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURLDownload.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CAAnimation.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CALayer.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CIImageProvider.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSInterfaceStyle.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSResponder</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSlider</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSlider.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSliderCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSliderCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTableView</string>
-					<string key="superclassName">NSControl</string>
-					<reference key="sourceIdentifier" ref="541644174"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSText</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSText.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextField</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextFieldCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextView</string>
-					<string key="superclassName">NSText</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSClipView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<reference key="sourceIdentifier" ref="287996405"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSRulerView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<string key="superclassName">NSResponder</string>
-					<reference key="sourceIdentifier" ref="721605179"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSDrawer.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSWindow</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSWindow.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSWindowScripting.h</string>
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSDocument.h</string>
 					</object>
 				</object>
 			</object>
@@ -4085,7 +3557,6 @@
 			<integer value="3000" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<string key="IBDocument.LastKnownRelativeProjectPath">../MacStreamingPlayer.xcodeproj</string>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
 		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
 			<bool key="EncodedWithXMLCoder">YES</bool>

--- a/MacStreamingPlayer.xcodeproj/project.pbxproj
+++ b/MacStreamingPlayer.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 				GCC_PREFIX_HEADER = MacStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = MacInfo.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = StreamingAudioPlayer;
 			};
 			name = Debug;
@@ -270,6 +271,7 @@
 				GCC_PREFIX_HEADER = MacStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = MacInfo.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = StreamingAudioPlayer;
 			};
 			name = Release;
@@ -277,14 +279,15 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 				WARNING_CFLAGS = "-Wall";
 			};
 			name = Debug;
@@ -292,12 +295,13 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/MacStreamingPlayer.xcodeproj/project.pbxproj
+++ b/MacStreamingPlayer.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1DDD58160DA1D0A300B32029 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1DDD58140DA1D0A300B32029 /* MainMenu.xib */; };
+		6802B7811354A36E0029B836 /* LevelMeterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6802B7801354A36E0029B836 /* LevelMeterView.m */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
@@ -29,6 +30,8 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		6802B77F1354A36E0029B836 /* LevelMeterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LevelMeterView.h; path = Classes/LevelMeterView.h; sourceTree = "<group>"; };
+		6802B7801354A36E0029B836 /* LevelMeterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LevelMeterView.m; path = Classes/LevelMeterView.m; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* StreamingAudioPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StreamingAudioPlayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9266EB70E8F1CCA00FFA634 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		C92672FA0E905BBB00FFA634 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = /System/Library/Frameworks/QuartzCore.framework; sourceTree = "<absolute>"; };
@@ -63,6 +66,8 @@
 			children = (
 				C9E673740FE8C7340033BF43 /* MacStreamingPlayerController.m */,
 				C9E673750FE8C7340033BF43 /* MacStreamingPlayerController.h */,
+				6802B77F1354A36E0029B836 /* LevelMeterView.h */,
+				6802B7801354A36E0029B836 /* LevelMeterView.m */,
 				C9E6736E0FE8C6F80033BF43 /* AudioStreamer.h */,
 				C9E6736F0FE8C6F80033BF43 /* AudioStreamer.m */,
 			);
@@ -210,6 +215,7 @@
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				C9E673700FE8C6F80033BF43 /* AudioStreamer.m in Sources */,
 				C9E673760FE8C7340033BF43 /* MacStreamingPlayerController.m in Sources */,
+				6802B7811354A36E0029B836 /* LevelMeterView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacStreamingPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MacStreamingPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:MacStreamingPlayer.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ History
 January 30, 2011
 
   * Forked [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).
+  * Replaced #ifdef TARGET_OS_IPHONE with #if TARGET_OS_IPHONE. This is Apple's recommend approach for [conditionalizing compilation and linking](http://developer.apple.com/library/ios/#documentation/Xcode/Conceptual/iphone_development/115-Configuring_Applications/configuring_applications.html#//apple_ref/doc/uid/TP40007959-CH19-SW3). Also, TargetConditionals.h header in Mac 10.6 SDK defines TARGET_OS_IPHONE as 0 so this change is needed if one wishes to compile against 10.6 or greater.
   * Merged shoutcast branch from [jfricker/AudioStreamer](https://github.com/jfricker/AudioStreamer) adding support for retrieving shoutcast metadata and replacing the alert display with a notification message.
   * Replaced SHOUTCAST_METADATA marco with retrieveShoutcastMetadata BOOL on the AudioStreamer class.
   * Added this README.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ History
 -------
 
 January 30, 2011
+
   * Merged shoutcast branch from [jfricker/AudioStreamer](https://github.com/jfricker/AudioStreamer) adding support for retrieving shoutcast metadata and replacing the alert display with a notification message.
   * Replaced SHOUTCAST_METADATA marco with retrieveShoutcastMetadata BOOL on the AudioStreamer class.
   * Added this README.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+AudioStreamer
+=============
+
+This is a fork of the [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer) repo.
+
+History
+-------
+
+January 30, 2011
+  * Merged shoutcast branch from [jfricker/AudioStreamer](https://github.com/jfricker/AudioStreamer) adding support for retrieving shoutcast metadata and replacing the alert display with a notification message.
+  * Replaced SHOUTCAST_METADATA marco with retrieveShoutcastMetadata BOOL on the AudioStreamer class.
+  * Added this README.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ History
 -------
 
 April 12, 2001
+
   * Updated AudioStream with the latest from [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).
   * Added level meter code from [idevsoftware/AudioStreamer](https://github.com/idevsoftware/AudioStreamer)
   * Added level meter display to the sample projects.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ History
 January 30, 2011
 
   * Forked [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).
-  * Replaced #ifdef TARGET_OS_IPHONE with #if TARGET_OS_IPHONE. This is Apple's recommend approach for [conditionalizing compilation and linking](http://developer.apple.com/library/ios/#documentation/Xcode/Conceptual/iphone_development/115-Configuring_Applications/configuring_applications.html#//apple_ref/doc/uid/TP40007959-CH19-SW3). Also, TargetConditionals.h header in Mac 10.6 SDK defines TARGET_OS_IPHONE as 0 so this change is needed if one wishes to compile against 10.6 or greater.
+  * Replaced #ifdef TARGET_OS_IPHONE with #if TARGET_OS_IPHONE. This is Apple's recommended approach for [conditionalizing compilation and linking](http://developer.apple.com/library/ios/#documentation/Xcode/Conceptual/iphone_development/115-Configuring_Applications/configuring_applications.html#//apple_ref/doc/uid/TP40007959-CH19-SW3). Also, TargetConditionals.h header in Mac 10.6 SDK defines TARGET_OS_IPHONE as 0 so this change is needed if one wishes to compile against 10.6 or greater.
   * Merged shoutcast branch from [jfricker/AudioStreamer](https://github.com/jfricker/AudioStreamer) adding support for retrieving shoutcast metadata and replacing the alert display with a notification message.
   * Replaced SHOUTCAST_METADATA marco with retrieveShoutcastMetadata BOOL on the AudioStreamer class.
   * Added this README.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This is a fork of the [mattgallagher/AudioStreamer](https://github.com/mattgalla
 History
 -------
 
+April 12, 2001
+  * Updated AudioStream with the latest from [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).
+  * Added level meter code from [idevsoftware/AudioStreamer](https://github.com/idevsoftware/AudioStreamer)
+  * Added level meter display to the sample projects.
+
 January 30, 2011
 
   * Forked [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ History
 
 January 30, 2011
 
+  * Forked [mattgallagher/AudioStreamer](https://github.com/mattgallagher/AudioStreamer).
   * Merged shoutcast branch from [jfricker/AudioStreamer](https://github.com/jfricker/AudioStreamer) adding support for retrieving shoutcast metadata and replacing the alert display with a notification message.
   * Replaced SHOUTCAST_METADATA marco with retrieveShoutcastMetadata BOOL on the AudioStreamer class.
   * Added this README.

--- a/iPhone Resources/iPhoneStreamingPlayerViewController.xib
+++ b/iPhone Resources/iPhoneStreamingPlayerViewController.xib
@@ -2,17 +2,17 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">528</int>
-		<string key="IBDocument.SystemVersion">10C540</string>
-		<string key="IBDocument.InterfaceBuilderVersion">762</string>
-		<string key="IBDocument.AppKitVersion">1038.25</string>
-		<string key="IBDocument.HIToolboxVersion">458.00</string>
+		<string key="IBDocument.SystemVersion">10F569</string>
+		<string key="IBDocument.InterfaceBuilderVersion">788</string>
+		<string key="IBDocument.AppKitVersion">1038.29</string>
+		<string key="IBDocument.HIToolboxVersion">461.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">87</string>
+			<string key="NS.object.0">117</string>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<integer value="46"/>
+			<integer value="6"/>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -45,18 +45,18 @@
 					<object class="IBUITextField" id="687637752">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 49}, {280, 31}}</string>
+						<string key="NSFrame">{{20, 49}, {300, 31}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<string key="IBUIText">http://202.6.74.107:8060/triplej.mp3</string>
+						<string key="IBUIText">http://casabastiano.shoutcaststream.com:8170</string>
 						<int key="IBUIBorderStyle">3</int>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MAA</bytes>
-							<object class="NSColorSpace" key="NSCustomColorSpace">
+							<object class="NSColorSpace" key="NSCustomColorSpace" id="847688059">
 								<int key="NSID">2</int>
 							</object>
 						</object>
@@ -174,6 +174,82 @@
 						<float key="IBUIMaxValue">100</float>
 						<bool key="IBUIContinuous">NO</bool>
 					</object>
+					<object class="IBUITextField" id="532623234">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{83, 228}, {217, 31}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<string key="IBUIText"/>
+						<int key="IBUIBorderStyle">3</int>
+						<object class="NSColor" key="IBUITextColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MAA</bytes>
+							<reference key="NSCustomColorSpace" ref="847688059"/>
+						</object>
+						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
+						<float key="IBUIMinimumFontSize">17</float>
+						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
+							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						</object>
+					</object>
+					<object class="IBUITextField" id="102281679">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{83, 267}, {217, 31}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<string key="IBUIText"/>
+						<int key="IBUIBorderStyle">3</int>
+						<object class="NSColor" key="IBUITextColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MAA</bytes>
+							<reference key="NSCustomColorSpace" ref="847688059"/>
+						</object>
+						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
+						<float key="IBUIMinimumFontSize">17</float>
+						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
+							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						</object>
+					</object>
+					<object class="IBUILabel" id="722774156">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 233}, {42, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Artist</string>
+						<reference key="IBUITextColor" ref="971594825"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
+					<object class="IBUILabel" id="976721683">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 270}, {42, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Title</string>
+						<reference key="IBUITextColor" ref="971594825"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
 				</object>
 				<string key="NSFrameSize">{320, 460}</string>
 				<reference key="NSSuperview"/>
@@ -263,6 +339,22 @@
 					</object>
 					<int key="connectionID">48</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">metadataTitle</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="102281679"/>
+					</object>
+					<int key="connectionID">56</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">metadataArtist</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="532623234"/>
+					</object>
+					<int key="connectionID">57</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -296,6 +388,10 @@
 							<reference ref="1000478862"/>
 							<reference ref="838238580"/>
 							<reference ref="1067123130"/>
+							<reference ref="532623234"/>
+							<reference ref="722774156"/>
+							<reference ref="976721683"/>
+							<reference ref="102281679"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -337,6 +433,26 @@
 						<reference key="object" ref="838238580"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">49</int>
+						<reference key="object" ref="532623234"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">50</int>
+						<reference key="object" ref="102281679"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">51</int>
+						<reference key="object" ref="722774156"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">52</int>
+						<reference key="object" ref="976721683"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -352,6 +468,10 @@
 					<string>26.IBPluginDependency</string>
 					<string>35.IBPluginDependency</string>
 					<string>46.IBPluginDependency</string>
+					<string>49.IBPluginDependency</string>
+					<string>50.IBPluginDependency</string>
+					<string>51.IBPluginDependency</string>
+					<string>52.IBPluginDependency</string>
 					<string>6.IBEditorWindowLastContentRect</string>
 					<string>6.IBPluginDependency</string>
 				</object>
@@ -366,7 +486,11 @@
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>{{829, 336}, {320, 480}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>{{623, 248}, {320, 480}}</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				</object>
 			</object>
@@ -386,7 +510,7 @@
 				</object>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">48</int>
+			<int key="maxID">57</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -407,12 +531,33 @@
 							<string>UISlider</string>
 						</object>
 					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>buttonPressed:</string>
+							<string>sliderMoved:</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">buttonPressed:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">sliderMoved:</string>
+								<string key="candidateClassName">UISlider</string>
+							</object>
+						</object>
+					</object>
 					<object class="NSMutableDictionary" key="outlets">
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>button</string>
 							<string>downloadSourceField</string>
+							<string>metadataArtist</string>
+							<string>metadataTitle</string>
 							<string>positionLabel</string>
 							<string>progressSlider</string>
 							<string>volumeSlider</string>
@@ -421,9 +566,55 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>UIButton</string>
 							<string>UITextField</string>
+							<string>UITextField</string>
+							<string>UITextField</string>
 							<string>UILabel</string>
 							<string>UISlider</string>
 							<string>UIView</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>button</string>
+							<string>downloadSourceField</string>
+							<string>metadataArtist</string>
+							<string>metadataTitle</string>
+							<string>positionLabel</string>
+							<string>progressSlider</string>
+							<string>volumeSlider</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">button</string>
+								<string key="candidateClassName">UIButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">downloadSourceField</string>
+								<string key="candidateClassName">UITextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">metadataArtist</string>
+								<string key="candidateClassName">UITextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">metadataTitle</string>
+								<string key="candidateClassName">UITextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">positionLabel</string>
+								<string key="candidateClassName">UILabel</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">progressSlider</string>
+								<string key="candidateClassName">UISlider</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">volumeSlider</string>
+								<string key="candidateClassName">UIView</string>
+							</object>
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
@@ -473,13 +664,6 @@
 					<string key="className">NSObject</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSNetServices.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
 						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
 					</object>
 				</object>
@@ -487,21 +671,7 @@
 					<string key="className">NSObject</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSPort.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
 						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSStream.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
@@ -523,13 +693,6 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
 						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSXMLParser.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
@@ -651,7 +814,28 @@
 					<string key="className">UIViewController</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">MediaPlayer.framework/Headers/MPMoviePlayerViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
 						<string key="minorKey">UIKit.framework/Headers/UINavigationController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIPopoverController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISplitViewController.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
@@ -679,7 +863,7 @@
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<integer value="768" key="NS.object.0"/>
+			<integer value="1024" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
@@ -692,6 +876,6 @@
 			<string key="NS.key.0">playbutton.png</string>
 			<string key="NS.object.0">{64, 64}</string>
 		</object>
-		<string key="IBCocoaTouchPluginVersion">87</string>
+		<string key="IBCocoaTouchPluginVersion">117</string>
 	</data>
 </archive>

--- a/iPhone Resources/iPhoneStreamingPlayerViewController.xib
+++ b/iPhone Resources/iPhoneStreamingPlayerViewController.xib
@@ -2,17 +2,22 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">528</int>
-		<string key="IBDocument.SystemVersion">10F569</string>
-		<string key="IBDocument.InterfaceBuilderVersion">788</string>
-		<string key="IBDocument.AppKitVersion">1038.29</string>
-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<string key="IBDocument.SystemVersion">10J567</string>
+		<string key="IBDocument.InterfaceBuilderVersion">1305</string>
+		<string key="IBDocument.AppKitVersion">1038.35</string>
+		<string key="IBDocument.HIToolboxVersion">462.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">117</string>
+			<string key="NS.object.0">300</string>
 		</object>
-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<integer value="6"/>
+			<string>IBUILabel</string>
+			<string>IBUISlider</string>
+			<string>IBUIButton</string>
+			<string>IBUIView</string>
+			<string>IBUITextField</string>
+			<string>IBProxyObject</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -23,9 +28,7 @@
 			<object class="NSArray" key="dict.sortedKeys" id="0">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 			</object>
-			<object class="NSMutableArray" key="dict.values">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
+			<reference key="dict.values" ref="0"/>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -47,11 +50,13 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 49}, {300, 31}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="650664856"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<string key="IBUIText">http://casabastiano.shoutcaststream.com:8170</string>
+						<string key="IBUIText">http://shoutmedia.abc.net.au:10326</string>
 						<int key="IBUIBorderStyle">3</int>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">3</int>
@@ -73,6 +78,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 20}, {280, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="687637752"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
@@ -91,6 +98,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{124, 88}, {72, 73}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="842916847"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -123,6 +132,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 169}, {280, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="838238580"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
@@ -138,6 +149,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 356}, {280, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1067123130"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
@@ -153,6 +166,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 385}, {280, 55}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MSAwAA</bytes>
@@ -165,6 +180,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{18, 198}, {284, 23}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="722774156"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<bool key="IBUIEnabled">NO</bool>
@@ -179,6 +196,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{83, 228}, {217, 31}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="976721683"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -201,6 +220,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{83, 267}, {217, 31}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1000478862"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -223,6 +244,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 233}, {42, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="532623234"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<int key="IBUIContentMode">7</int>
@@ -239,6 +262,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 270}, {42, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="102281679"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<int key="IBUIContentMode">7</int>
@@ -251,8 +276,10 @@
 						<float key="IBUIMinimumFontSize">10</float>
 					</object>
 				</object>
-				<string key="NSFrameSize">{320, 460}</string>
+				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="1010863368"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">1</int>
 					<bytes key="NSRGB">MC44NTIwNDA4MyAwLjg1MjA0MDgzIDAuODUyMDQwODMAA</bytes>
@@ -497,17 +524,13 @@
 			<object class="NSMutableDictionary" key="unlocalizedProperties">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="activeLocalization"/>
 			<object class="NSMutableDictionary" key="localizations">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
 			<int key="maxID">57</int>
@@ -619,238 +642,7 @@
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/iPhoneStreamingPlayerViewController.h</string>
-					</object>
-				</object>
-			</object>
-			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CAAnimation.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CALayer.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QuartzCore.framework/Headers/CIImageProvider.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIAccessibility.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UINibLoading.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="36998061">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIResponder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIButton</string>
-					<string key="superclassName">UIControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIControl</string>
-					<string key="superclassName">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIControl.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UILabel</string>
-					<string key="superclassName">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UILabel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIResponder</string>
-					<string key="superclassName">NSObject</string>
-					<reference key="sourceIdentifier" ref="36998061"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UISearchBar</string>
-					<string key="superclassName">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UISearchBar.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UISearchDisplayController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UISearchDisplayController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UISlider</string>
-					<string key="superclassName">UIControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UISlider.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UITextField</string>
-					<string key="superclassName">UIControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="680345137">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UITextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIView</string>
-					<reference key="sourceIdentifier" ref="680345137"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIView</string>
-					<string key="superclassName">UIResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">MediaPlayer.framework/Headers/MPMoviePlayerViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UINavigationController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIPopoverController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UISplitViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UITabBarController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<string key="superclassName">UIResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIViewController.h</string>
+						<string key="minorKey">./Classes/iPhoneStreamingPlayerViewController.h</string>
 					</object>
 				</object>
 			</object>
@@ -870,12 +662,11 @@
 			<integer value="3000" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<string key="IBDocument.LastKnownRelativeProjectPath">../iPhoneStreamingPlayer.xcodeproj</string>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
 		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
 			<string key="NS.key.0">playbutton.png</string>
 			<string key="NS.object.0">{64, 64}</string>
 		</object>
-		<string key="IBCocoaTouchPluginVersion">117</string>
+		<string key="IBCocoaTouchPluginVersion">300</string>
 	</data>
 </archive>

--- a/iPhone Resources/iPhoneStreamingPlayerViewController.xib
+++ b/iPhone Resources/iPhoneStreamingPlayerViewController.xib
@@ -56,7 +56,7 @@
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<string key="IBUIText">http://shoutmedia.abc.net.au:10326</string>
+						<string key="IBUIText">http://scfire-dtc-aa06.stream.aol.com:80/stream/1018</string>
 						<int key="IBUIBorderStyle">3</int>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">3</int>
@@ -147,7 +147,7 @@
 					<object class="IBUILabel" id="1000478862">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 356}, {280, 21}}</string>
+						<string key="NSFrame">{{20, 367}, {280, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1067123130"/>
@@ -164,7 +164,7 @@
 					<object class="IBUIView" id="1067123130">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 385}, {280, 55}}</string>
+						<string key="NSFrame">{{20, 391}, {280, 55}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>

--- a/iPhoneInfo.plist
+++ b/iPhoneInfo.plist
@@ -26,5 +26,9 @@
 	<true/>
 	<key>NSMainNibFile</key>
 	<string>MainWindow</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
+++ b/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
 		28D7ACF80DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.m */; };
+		6802B77E13549F2B0029B836 /* LevelMeterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6802B77D13549F2B0029B836 /* LevelMeterView.m */; };
 		C9423DF10EF8AA6B003B785B /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9423DF00EF8AA6B003B785B /* CFNetwork.framework */; };
 		C9AB93E20FCF816F0047C0FA /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9AB93E10FCF816F0047C0FA /* AudioToolbox.framework */; };
 		C9AB93F30FCF81790047C0FA /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9AB93F20FCF81790047C0FA /* MediaPlayer.framework */; };
@@ -37,6 +38,8 @@
 		28D7ACF70DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iPhoneStreamingPlayerViewController.m; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* iPhoneStreamingPlayer_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iPhoneStreamingPlayer_Prefix.pch; sourceTree = "<group>"; };
+		6802B77C13549F2B0029B836 /* LevelMeterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LevelMeterView.h; sourceTree = "<group>"; };
+		6802B77D13549F2B0029B836 /* LevelMeterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LevelMeterView.m; sourceTree = "<group>"; };
 		C9423DF00EF8AA6B003B785B /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		C9AB93E10FCF816F0047C0FA /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		C9AB93F20FCF81790047C0FA /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
@@ -79,6 +82,8 @@
 				1D3623250D0F684500981E51 /* iPhoneStreamingPlayerAppDelegate.m */,
 				28D7ACF60DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.h */,
 				28D7ACF70DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.m */,
+				6802B77C13549F2B0029B836 /* LevelMeterView.h */,
+				6802B77D13549F2B0029B836 /* LevelMeterView.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -209,6 +214,7 @@
 				1D3623260D0F684500981E51 /* iPhoneStreamingPlayerAppDelegate.m in Sources */,
 				28D7ACF80DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.m in Sources */,
 				C9C2D87A0EB6E09C00A3D071 /* AudioStreamer.m in Sources */,
+				6802B77E13549F2B0029B836 /* LevelMeterView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,6 +257,7 @@
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
 				PROVISIONING_PROFILE = "";
@@ -266,6 +273,7 @@
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				PREBINDING = NO;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;

--- a/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
+++ b/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iPhoneStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = iPhoneInfo.plist;
+				OTHER_CFLAGS = "-DSHOUTCAST_METADATA=1";
 				PRODUCT_NAME = iPhoneStreamingPlayer;
 			};
 			name = Debug;
@@ -237,6 +238,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iPhoneStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = iPhoneInfo.plist;
+				OTHER_CFLAGS = "-DSHOUTCAST_METADATA=1";
 				PRODUCT_NAME = iPhoneStreamingPlayer;
 			};
 			name = Release;

--- a/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
+++ b/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
@@ -73,8 +73,8 @@
 		080E96DDFE201D6D7F000001 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				C9C2D8780EB6E09C00A3D071 /* AudioStreamer.m */,
 				C9C2D8790EB6E09C00A3D071 /* AudioStreamer.h */,
+				C9C2D8780EB6E09C00A3D071 /* AudioStreamer.m */,
 				1D3623240D0F684500981E51 /* iPhoneStreamingPlayerAppDelegate.h */,
 				1D3623250D0F684500981E51 /* iPhoneStreamingPlayerAppDelegate.m */,
 				28D7ACF60DDB3853001CB0EB /* iPhoneStreamingPlayerViewController.h */,
@@ -225,7 +225,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iPhoneStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = iPhoneInfo.plist;
-				OTHER_CFLAGS = "-DSHOUTCAST_METADATA=1";
+				OTHER_CFLAGS = "";
 				PRODUCT_NAME = iPhoneStreamingPlayer;
 			};
 			name = Debug;
@@ -238,7 +238,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iPhoneStreamingPlayer_Prefix.pch;
 				INFOPLIST_FILE = iPhoneInfo.plist;
-				OTHER_CFLAGS = "-DSHOUTCAST_METADATA=1";
+				OTHER_CFLAGS = "";
 				PRODUCT_NAME = iPhoneStreamingPlayer;
 			};
 			name = Release;

--- a/iPhoneStreamingPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iPhoneStreamingPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:iPhoneStreamingPlayer.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/main.m
+++ b/main.m
@@ -12,7 +12,7 @@
 //  appreciated but not required.
 //
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #else
 #import <Cocoa/Cocoa.h>
@@ -20,7 +20,7 @@
 
 int main(int argc, const char *argv[]) {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
     int retVal = UIApplicationMain(argc, (char **)argv, nil, nil);
 #else
     int retVal = NSApplicationMain(argc, argv);


### PR DESCRIPTION
Hi Matt,

TargetConditionals.h header for Mac 10.6 SDK defines TARGET_OS_IPHONE as 0. This means if you compile AudioStreamer against 10.6 it will attempt to compile the iOS specific code. I changed #ifdef TARGET_OS_IPHONE to #if TARGET_OS_IPHONE so the code will build using the Mac 10.6 SDK.

Also, using #if TARGET_OS_IPHONE is recommended by Apple in the Compiling Source Code Conditionally for iOS Applications section of the iOS Development Guide (http://bit.ly/fShoE0).

By the way, thanks for sharing AudioStreamer. It is really useful.

-KIRBY
