### PR TITLE
Set file extension

### DIFF
--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -131,6 +131,7 @@ extern NSString * const ASStatusChangedNotification;
 	bool inuse[kNumAQBufs];			// flags to indicate that a buffer is still in use
 	NSInteger buffersUsed;
 	NSDictionary *httpHeaders;
+    NSString *fileExtension;
 	
 	AudioStreamerState state;
 	AudioStreamerStopReason stopReason;
@@ -175,6 +176,7 @@ extern NSString * const ASStatusChangedNotification;
 @property (readonly) double duration;
 @property (readwrite) UInt32 bitRate;
 @property (readonly) NSDictionary *httpHeaders;
+@property (retain,readwrite) NSString *fileExtension;
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -131,7 +131,7 @@ extern NSString * const ASStatusChangedNotification;
 	bool inuse[kNumAQBufs];			// flags to indicate that a buffer is still in use
 	NSInteger buffersUsed;
 	NSDictionary *httpHeaders;
-    NSString *fileExtension;
+	NSString *fileExtension;
 	
 	AudioStreamerState state;
 	AudioStreamerStopReason stopReason;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -176,7 +176,7 @@ extern NSString * const ASStatusChangedNotification;
 @property (readonly) double duration;
 @property (readwrite) UInt32 bitRate;
 @property (readonly) NSDictionary *httpHeaders;
-@property (retain,readwrite) NSString *fileExtension;
+@property (copy,readwrite) NSString *fileExtension;
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -223,6 +223,7 @@ void ASReadStreamCallBack
 @synthesize state;
 @synthesize bitRate;
 @synthesize httpHeaders;
+@synthesize fileExtension;
 
 //
 // initWithURL
@@ -248,6 +249,7 @@ void ASReadStreamCallBack
 {
 	[self stop];
 	[url release];
+    [fileExtension release];
 	[super dealloc];
 }
 
@@ -1296,8 +1298,12 @@ cleanup:
 			//
 			// If you have a fixed file-type, you may want to hardcode this.
 			//
+            if (!self.fileExtension)
+            {
+                 self.fileExtension = [[url path] pathExtension];
+            }
 			AudioFileTypeID fileTypeHint =
-				[AudioStreamer hintForFileExtension:[[url path] pathExtension]];
+				[AudioStreamer hintForFileExtension:self.fileExtension];
 
 			// create an audio file stream parser
 			err = AudioFileStreamOpen(self, MyPropertyListenerProc, MyPacketsProc, 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -249,7 +249,7 @@ void ASReadStreamCallBack
 {
 	[self stop];
 	[url release];
-    [fileExtension release];
+	[fileExtension release];
 	[super dealloc];
 }
 
@@ -1298,10 +1298,10 @@ cleanup:
 			//
 			// If you have a fixed file-type, you may want to hardcode this.
 			//
-            if (!self.fileExtension)
-            {
-                 self.fileExtension = [[url path] pathExtension];
-            }
+			if (!self.fileExtension)
+			{
+				self.fileExtension = [[url path] pathExtension];
+			}
 			AudioFileTypeID fileTypeHint =
 				[AudioStreamer hintForFileExtension:self.fileExtension];
 


### PR DESCRIPTION
Added fileExtension member to aid/override detection of stream type for URLs without an extension present.

Comment at line 1297 of AudioStreamer.m mentions possibly having to hardcode a file-type if the detection doesn't work based on the stream URL.

Trying to avoid this, I have added a fileExtension member that can be set from whatever is instantiating AudioStreamer (your view controller or whatever) to aid it in playing these kinds of streams. If not set it will continue to attempt detection based on the URL.
