### PR TITLE
Fixed memory leak

### DIFF
--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -1616,6 +1616,7 @@ cleanup:
 	        err = AudioFileStreamGetProperty(inAudioFileStream, kAudioFileStreamProperty_FormatList, &formatListSize, formatList);
 			if (err)
 			{
+				free(formatList);
 				[self failWithErrorCode:AS_FILE_STREAM_GET_PROPERTY_FAILED];
 				return;
 			}


### PR DESCRIPTION
Fixed so that if the call to AudioFileStreamGetProperty() returns an error, the memory allocated for the formatList variable is properly released. 
