### PR TITLE
Added hintForMimeType: method

### DIFF
--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -603,6 +603,50 @@ void ASReadStreamCallBack
 }
 
 //
+// hintForMIMEType
+//
+// Make a more informed guess on the file type based on the MIME type
+//
+// Parameters:
+//    mimeType - the MIME type
+//
+// returns a file type hint that can be passed to the AudioFileStream
+//
++ (AudioFileTypeID)hintForMIMEType:(NSString *)mimeType
+{
+	AudioFileTypeID fileTypeHint = kAudioFileMP3Type;
+	if ([mimeType isEqual:@"audio/mpeg"])
+	{
+		fileTypeHint = kAudioFileMP3Type;
+	}
+	else if ([mimeType isEqual:@"audio/x-wav"])
+	{
+		fileTypeHint = kAudioFileWAVEType;
+	}
+	else if ([mimeType isEqual:@"audio/x-aiff"])
+	{
+		fileTypeHint = kAudioFileAIFFType;
+	}
+	else if ([mimeType isEqual:@"audio/x-m4a"])
+	{
+		fileTypeHint = kAudioFileM4AType;
+	}
+	else if ([mimeType isEqual:@"audio/mp4"])
+	{
+		fileTypeHint = kAudioFileMPEG4Type;
+	}
+	else if ([mimeType isEqual:@"audio/x-caf"])
+	{
+		fileTypeHint = kAudioFileCAFType;
+	}
+	else if ([mimeType isEqual:@"audio/aac"] || [mimeType isEqual:@"audio/aacp"])
+	{
+		fileTypeHint = kAudioFileAAC_ADTSType;
+	}
+	return fileTypeHint;
+}
+
+//
 // openReadStream
 //
 // Open the audioFileStream to parse data and the fileHandle as the data
@@ -1274,14 +1318,12 @@ cleanup:
 		if (!audioFileStream)
 		{
 			//
-			// Attempt to guess the file type from the URL. Reading the MIME type
-			// from the httpHeaders might be a better approach since lots of
-			// URL's don't have the right extension.
+			// Attempt to guess the file type from the httpHeaders MIME type value.
 			//
 			// If you have a fixed file-type, you may want to hardcode this.
 			//
 			AudioFileTypeID fileTypeHint =
-				[AudioStreamer hintForFileExtension:[[url path] pathExtension]];
+				[AudioStreamer hintForMIMEType:[httpHeaders objectForKey:@"Content-Type"]];
 
 			// create an audio file stream parser
 			err = AudioFileStreamOpen(self, MyPropertyListenerProc, MyPacketsProc, 


### PR DESCRIPTION
Several years later, I really should get around to submitting this as a pull request!

I've added a hintForMimeType: method which returns an appropriate AudioFileTypeID hint for a valid audio file format MIME type, as suggested in the current codebase comments. Also modified handleReadFromStream:eventType: to utilise this new method.

I retained the old hintForFileExtension: method in the code base as it is perfectly functional and, in some cases, may be preferred to using the MIME type detection.
