### PR TITLE
AVAudioSession + Enabled Background Mode

### DIFF
--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -27,6 +27,8 @@
 #import <Cocoa/Cocoa.h>
 #endif // TARGET_OS_IPHONE
 
+#import <AVFoundation/AVAudioSession.h>
+
 #include <pthread.h>
 #include <AudioToolbox/AudioToolbox.h>
 
@@ -108,7 +110,7 @@ typedef enum
 
 extern NSString * const ASStatusChangedNotification;
 
-@interface AudioStreamer : NSObject
+@interface AudioStreamer : NSObject <AVAudioSessionDelegate>
 {
 	NSURL *url;
 

--- a/Classes/iPhoneStreamingPlayerViewController.m
+++ b/Classes/iPhoneStreamingPlayerViewController.m
@@ -206,7 +206,9 @@
 		
 		[self createStreamer];
 		[self setButtonImageNamed:@"loadingbutton.png"];
-		[streamer start];
+		
+        [[AVAudioSession sharedInstance] setDelegate:streamer];
+        [streamer start];
 	}
 	else
 	{

--- a/iPhoneInfo.plist
+++ b/iPhoneInfo.plist
@@ -26,5 +26,9 @@
 	<true/>
 	<key>NSMainNibFile</key>
 	<string>MainWindow</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
+++ b/iPhoneStreamingPlayer.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C9E6730A0FE8C5650033BF43 /* stopbutton.png in Resources */ = {isa = PBXBuildFile; fileRef = C9E673060FE8C5650033BF43 /* stopbutton.png */; };
 		C9E6730B0FE8C5650033BF43 /* loadingbutton.png in Resources */ = {isa = PBXBuildFile; fileRef = C9E673070FE8C5650033BF43 /* loadingbutton.png */; };
 		C9E6730C0FE8C5650033BF43 /* pausebutton.png in Resources */ = {isa = PBXBuildFile; fileRef = C9E673080FE8C5650033BF43 /* pausebutton.png */; };
+		EBF782C21922AB8E00DB9884 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBF782C11922AB8E00DB9884 /* AVFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		C9E673070FE8C5650033BF43 /* loadingbutton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = loadingbutton.png; path = "Shared Resources/loadingbutton.png"; sourceTree = "<group>"; };
 		C9E673080FE8C5650033BF43 /* pausebutton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = pausebutton.png; path = "Shared Resources/pausebutton.png"; sourceTree = "<group>"; };
 		C9E673410FE8C6510033BF43 /* iPhoneInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = iPhoneInfo.plist; sourceTree = "<group>"; };
+		EBF782C11922AB8E00DB9884 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EBF782C21922AB8E00DB9884 /* AVFoundation.framework in Frameworks */,
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
 				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
 				288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */,
@@ -132,6 +135,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EBF782C11922AB8E00DB9884 /* AVFoundation.framework */,
 				C9AB93F20FCF81790047C0FA /* MediaPlayer.framework */,
 				C9AB93E10FCF816F0047C0FA /* AudioToolbox.framework */,
 				C9423DF00EF8AA6B003B785B /* CFNetwork.framework */,
@@ -170,6 +174,15 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0500;
+				TargetAttributes = {
+					1D6058900D05DD3D006BFB54 = {
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
+					};
+				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "iPhoneStreamingPlayer" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
- updated to remove deprecated AudioSession warnings by replacing with
  iOS 7’s AVAudioSession framework
- enabled Background Audio mode by default to save some earlier confusion in the issues thread.

I've tested background mode and phone call interruptions and both seem stable to me but would appreciate some more testing

changes made were based on the work by http://github.com/software-mariodiana/AudioBufferPlayer/wiki/Replacing-C-functions-deprecated-in-iOS-7
