### PR TITLE
Fixing bit-rate calculation, thus fixing 'duration' and  'progress' parameters for long files

### DIFF
--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -1086,8 +1086,7 @@ cleanup:
 {
 	if (packetDuration && processedPacketsCount > BitRateEstimationMinPackets)
 	{
-		double averagePacketByteSize = processedPacketsSizeTotal / processedPacketsCount;
-		return 8.0 * averagePacketByteSize / packetDuration;
+		return processedPacketsSizeTotal / processedPacketsCount;
 	}
 	
 	if (bitRate)
@@ -1730,7 +1729,7 @@ cleanup:
 			
 			if (processedPacketsCount < BitRateEstimationMaxPackets)
 			{
-				processedPacketsSizeTotal += packetSize;
+				processedPacketsSizeTotal += 8.0 * packetSize / packetDuration;
 				processedPacketsCount += 1;
 			}
 			

--- a/Classes/iPhoneStreamingPlayerViewController.m
+++ b/Classes/iPhoneStreamingPlayerViewController.m
@@ -270,9 +270,9 @@
 		if (duration > 0)
 		{
 			[positionLabel setText:
-				[NSString stringWithFormat:@"Time Played: %.1f/%.1f seconds",
-					progress,
-					duration]];
+				[NSString stringWithFormat:@"Time Played: %@/%@",
+					[self stringFromTimeInterval:progress],
+					[self stringFromTimeInterval:duration]]];
 			[progressSlider setEnabled:YES];
 			[progressSlider setValue:100 * progress / duration];
 		}
@@ -287,6 +287,17 @@
 	}
 }
 
+//
+// To get the time formatted in HH:MM:SS format
+// Takes a second value, and returns a formatted string
+//
+- (NSString *)stringFromTimeInterval:(CGFloat)interval {
+    NSInteger ti = (NSInteger)interval;
+    NSInteger seconds = ti % 60;
+    NSInteger minutes = (ti / 60) % 60;
+    NSInteger hours = (ti / 3600);
+    return [NSString stringWithFormat:@"%02ld:%02ld:%02ld", (long)hours, (long)minutes, (long)seconds];
+}
 //
 // textFieldShouldReturn:
 //


### PR DESCRIPTION
 Precision was lost when summing up all the bit-rates together and then dividing it with the count in the -calculateBitRate method. So the bit rate looses couple hundred bits, and thus shows wrong duration for long files, also give wrong progress.

Can be tested with this 60 minute voice sync file given below, run it on VLC or some other player, its total duration is actually 1 hour 36 second, but without the fix of bit-rate, it shows 1 hour 56 second or something. And after every seek, it shows some extra seconds as current progress.

Also added a small method for break down the seconds to HH:MM:SS so that we can take a better look at duration and progress time.

Download the test file from here: https://www.dropbox.com/s/lwg8o42hkpweoxw/60minSyncTest.mp3?dl=0
